### PR TITLE
Self-managed console

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,12 +99,44 @@ jobs:
           cd release-artifacts
           sha256sum *.vsix > SHA256SUMS.txt
 
+      - name: Extract release notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          extract_section() {
+            awk -v heading="$1" '
+              /^##[[:space:]]+/ {
+                current = $0
+                sub(/^##[[:space:]]+/, "", current)
+                sub(/[[:space:]]+-.*$/, "", current)
+                sub(/^\[/, "", current)
+                sub(/\]$/, "", current)
+                if (current == heading) {
+                  in_section = 1
+                  next
+                }
+                if (in_section) {
+                  exit
+                }
+              }
+              in_section { print }
+            ' CHANGELOG.md
+          }
+          extract_section "$version" > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            extract_section "Unreleased" > release-notes.md
+          fi
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::error::CHANGELOG.md does not contain a section for ${version} or Unreleased."
+            exit 1
+          fi
+          printf '\nFull changelog: https://github.com/%s/blob/%s/CHANGELOG.md\n' \
+            "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" >> release-notes.md
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v3
         with:
           name: R Console ${{ github.ref_name }}
-          body: |
-            Full changelog: https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGELOG.md
+          body_path: release-notes.md
           files: |
             release-artifacts/*.vsix
             release-artifacts/SHA256SUMS.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to R Console will be documented in this file.
 
+## [0.2.0] - Unreleased
+
+### Added
+- Self-managed R console sessions with Command Palette management for attaching to or closing running sessions.
+
+### Fixed
+- Nested prompt handling now preserves reply input and multiline paste behavior while R is waiting for input.
+- R event and input-handler pumping now keeps interactive event loops responsive and interruptible.
+
 ## [0.1.1] - 2026-04-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to R Console will be documented in this file.
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-05-02
 
 ### Added
 - Persistent self-managed console sessions that can survive VS Code terminal UI detaches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to R Console will be documented in this file.
 ## [0.2.0] - Unreleased
 
 ### Added
-- Self-managed R console sessions with Command Palette management for attaching to or closing running sessions.
+- Persistent self-managed console sessions that can survive VS Code terminal UI detaches.
+- A session manager for attaching to or closing running R Console sessions.
+- Backend/UI transport over a TCP session server with reconnect metadata.
+- Persistence for console runtime state, terminal replay state, prompt/input state, and terminal location for later reattach.
 
 ### Fixed
 - Nested prompt handling now preserves reply input and multiline paste behavior while R is waiting for input.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Implementation details are documented in [docs/IMPLEMENTATION.md](docs/IMPLEMENT
 
 Launch `R Console` from the Command Palette with:
 
-- `R: Create R Console`
-- `R: Create R Console in Side Editor`
+- `R Console: Create R Console`
+- `R Console: Create R Console in Side Editor`
 
 The minimum vscode-R setup for those commands to work is:
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ npm run stage:sidecar
 npm run package
 ```
 
-This produces a target-specific VSIX for the current host platform, for example `vscode-r-console-0.1.1-win32-x64.vsix`.
+This produces a target-specific VSIX for the current host platform, for example `vscode-r-console-0.2.0-win32-x64.vsix`.
 
 `vscode:prepublish` still prepares the production bundle and stages the current platform binary into `bundled/bin/`.
 
 Each target-specific VSIX contains exactly one platform-matching `R_CONSOLE_HOST` binary in `bundled/bin/`.
 
-Pushing a tag that matches `package.json`'s version, for example `v0.1.1`, runs the GitHub release workflow. It packages six target-specific builds (`win32-x64`, `win32-arm64`, `linux-x64`, `linux-arm64`, `darwin-x64`, and `darwin-arm64`), generates `SHA256SUMS.txt`, and creates or updates the GitHub release for that tag. `workflow_dispatch` still acts as a packaging-only dry run.
+Pushing a tag that matches `package.json`'s version, for example `v0.2.0`, runs the GitHub release workflow. It packages six target-specific builds (`win32-x64`, `win32-arm64`, `linux-x64`, `linux-arm64`, `darwin-x64`, and `darwin-arm64`), generates `SHA256SUMS.txt`, and creates or updates the GitHub release for that tag. `workflow_dispatch` still acts as a packaging-only dry run.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,15 @@ Implementation details are documented in [docs/IMPLEMENTATION.md](docs/IMPLEMENT
 ## Features
 
 - Custom R console hosted in the VS Code terminal area.
+- Embedded console backend for macOS, Linux, and Windows
+- Session watcher integration with vscode-R for search-path data, global-environment data, and runtime `$` / `@` member completion.
+- Self-managed R console sessions that can be attached to or closed from VS Code.
+- Console-scoped completion and signature help through R's `languageserver` package.
+- Immediate local syntax highlighting plus semantic-token styling also through `languageserver`.
 - Multiline editing with local history navigation, reverse search, and a windowed/collapsed viewport renderer for long inputs.
 - Auto-matching brackets and quotes.
 - Bracketed paste handling.
 - Parser-backed completeness checks before submission.
-- Console-scoped completion and signature help through R's `languageserver` package.
-- Session watcher integration with vscode-R for search-path data, global-environment data, and runtime `$` / `@` member completion.
-- Immediate local syntax highlighting plus semantic-token styling also through `languageserver`.
-- Screen, scrollback, cursor, and ANSI style restoration when the terminal UI is recreated after a cancelled close or a reattach.
-- Close confirmation that immediately reattaches the running console before showing the modal prompt, which keeps the console visible despite the VS Code terminal API lacking a before-close hook.
-- Embedded console backend for macOS, Linux, and Windows.
 
 ## Requirements
 
@@ -33,8 +32,11 @@ Launch `R Console` from the Command Palette with:
 
 - `R Console: Create R Console`
 - `R Console: Create R Console in Side Editor`
+- `R Console: Manage Persistent Sessions...`
 
-The minimum vscode-R setup for those commands to work is:
+Use the session manager to attach to or close running R Console sessions.
+
+The minimum vscode-R setup for R Console commands to work is:
 
 1. Install [vscode-R](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r).
 2. Prefer setting the platform-specific vscode-R `r.rpath.*` entry to the R binary path used by `R Console`:
@@ -110,44 +112,26 @@ R Console also contributes its own settings:
 | `r.console.autoMatch` | `true` | Auto-insert matching brackets and quotes |
 | `r.console.tabSize` | `2` | Indentation width |
 
-## Architecture
-
-### Runtime Layers
-
-1. Terminal layer owns the pseudoterminal implementation, input buffer, cursor movement, multiline editing, history, the long-input viewport renderer, prompt handling, and an off-screen `@xterm/headless` buffer used to restore screen and scrollback state on reattach.
-
-2. Language layer owns completion-context analysis, local parse heuristics, immediate token-based styling, virtual documents, and the console-specific LSP bridge.
-
-3. Runtime layer owns the sidecar/session control protocol, bundled binary resolution, dialog bridging, and the vscode-R session watcher bridge.
-
-4. Rust sidecar
-- `sidecar/pty-host/` builds one binary:
-- `R_CONSOLE_HOST` is the embedded host. It does not spawn a second internal session-host process. It loads the R shared library dynamically, wires console callbacks, and emits prompt, busy, input-request, dialog, and parse-status events back to the extension over the backend protocol.
-
-### Dependency Model
+## Dependency Model
 
 - `vscode-R` is a hard dependency. R Console uses the same configured R binary.
 - R's `languageserver` package is optional but required for console semantic tokens, completion, and signature help.
 - The bundled `R_CONSOLE_HOST` sidecar is required at runtime. If the bundled binary for the current target is missing, the console does not fall back to a separate backend.
-
-## Project Layout
-
-- `src/Terminal/` contains the console editor, viewport renderer, history manager, headless replay/restore logic, options, and the main `RTerminal` implementation.
-- `src/Language/` contains completion logic, the console LSP client, parse heuristics, and the virtual in-memory R document.
-- `src/Runtime/` contains the backend control protocol, bundled Rust binary resolution, and the session watcher integration.
-- `sidecar/pty-host/` contains the Rust embedded host and protocol framing code.
 
 ## Acknowledgements
 
 R Console is built on the broader VS Code, Rust, and R ecosystems, and on the work of open-source projects that informed the extension. In particular, we would like to highlight the following projects:
 
 - [vscode-R](https://github.com/REditorSupport/vscode-R) - R Console depends on vscode-R for configuration, session bootstrap, session watching, and the surrounding VS Code R workflow.
-- [arf](https://github.com/eitsupi/arf) - The current embedded-R host design was heavily informed by arf's Rust-based approach to loading and embedding R, platform-specific console initialization, callback wiring, and backend architecture.
+- [arf](https://github.com/eitsupi/arf) - The embedded-R host design was heavily informed by arf's Rust-based approach to loading and embedding R, platform-specific console initialization, callback wiring, event/input-handler pumping, and backend architecture.
+- [Ark](https://github.com/posit-dev/ark) - The native R frontend model, nested-input handling, ReadConsole recovery concepts, and generic R event-loop integration were important references for the backend design.
+- [rchitect](https://github.com/randy3k/rchitect) - Rchitect was a reference for embedding R from a non-R host process, including R home/shared-library discovery and callback/FFI boundary concepts.
 - [radian](https://github.com/randy3k/radian) - The terminal-first interaction model and several console UX ideas, including multiline editing, history search/navigation, bracketed paste, and prompt-centric workflows, were inspired by radian.
+- [languageserver](https://github.com/REditorSupport/languageserver) - Console completion, signature help, and semantic-token support are built around R's language server.
 
 ## Development Note
 
-This extension's source code was written with assistance from Codex (GPT-5.3-Codex and GPT-5.4). The overall feature design and logic decisions are mine; GPT models were used to generate and iterate on the implementation.
+This extension's source code was written with assistance from GPT models using OpenAI's Codex. The overall feature design and logic decisions are mine; GPT models were used to generate and iterate on the implementation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ Implementation details are documented in [docs/IMPLEMENTATION.md](docs/IMPLEMENT
 
 https://github.com/user-attachments/assets/a1b7390e-eb33-4b9d-8915-85ae51c3039d
 
-
-https://github.com/user-attachments/assets/a1b7390e-eb33-4b9d-8915-85ae51c3039d
-
 ## Requirements
 
 - VS Code 1.85.0 or later.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Implementation details are documented in [docs/IMPLEMENTATION.md](docs/IMPLEMENT
 - Bracketed paste handling.
 - Parser-backed completeness checks before submission.
 
+https://github.com/user-attachments/assets/a1b7390e-eb33-4b9d-8915-85ae51c3039d
+
+
 ## Requirements
 
 - VS Code 1.85.0 or later.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -617,12 +617,16 @@ It marks R as interactive and captures:
 
 Unix idle/event pumping uses:
 
+- optional `R_ProcessEvents`
 - `R_checkActivity`
 - `R_runHandlers`
 - `R_InputHandlers`
 - optional `R_PolledEvents`
+- optional `R_RunPendingFinalizers`
 
-The host pumps these while waiting in `ReadConsole`.
+The host pumps these while waiting in `ReadConsole`. Package event loops are
+serviced only through R's generic event and input-handler APIs; the backend does
+not special-case individual R packages.
 
 ### 11.5 Interrupt model
 
@@ -632,6 +636,12 @@ Unix interrupts use both:
 - a real `SIGINT` to the current process
 
 That combination is what the current Unix backend actually does.
+On the first real top-level `ReadConsole` turn, the host also injects a generic
+base R interrupt calling handler with `globalCallingHandlers()`. That handler
+invokes R's `abort` restart for interrupt conditions, which lets R unwind
+through normal `on.exit` cleanup before the next console command is accepted.
+This is installed through base R only; it does not inspect or call any
+package-specific APIs.
 
 ## 12. Windows Backend Implementation
 
@@ -688,6 +698,7 @@ The host loads Windows-specific symbols when present:
 - `GA_initapp`
 - `GA_peekevent`
 - `R_ProcessEvents`
+- `R_RunPendingFinalizers`
 - `CharacterMode`
 - `UserBreak` or fallback `R_interrupts_pending`
 
@@ -735,12 +746,12 @@ but it does not stop there.
 Current behavior:
 
 - the explicit idle pump drains the Windows message queue with `PeekMessageW` / `DispatchMessageW`
-- optional input handlers still run through `R_checkActivity`, `R_runHandlers`, and `R_InputHandlers` when those symbols are available
-- `later` callbacks are executed when `later.dll` is loaded
 - `R_ProcessEvents()` is called when available
+- optional input handlers still run through `R_checkActivity`, `R_runHandlers`, and `R_InputHandlers` when those symbols are available
+- pending finalizers are run through `R_RunPendingFinalizers()` when available
 - the callback path (`process_events_callback` / `polled_events_callback`) also pumps Windows messages and available handlers
 
-This is what keeps Windows graphapp/help/GUI event processing moving while the console is waiting for input, while still servicing handler-driven and `later`-driven work.
+This is what keeps Windows graphapp/help/GUI event processing moving while the console is waiting for input, while still servicing handler-driven work through R's generic event APIs. The backend does not call package-specific event functions.
 
 ### 12.7 Interrupt model
 
@@ -751,7 +762,12 @@ The host sets:
 - `UserBreak` when exported
 - otherwise `R_interrupts_pending`
 
-It also calls `R_CheckUserInterrupt` when needed after interrupted reads.
+It also calls `R_CheckUserInterrupt` when needed after interrupted nested reads.
+On the first real top-level `ReadConsole` turn, the host injects a generic base
+R interrupt calling handler with `globalCallingHandlers()`. That handler invokes
+R's `abort` restart for interrupt conditions, which lets R unwind through normal
+`on.exit` cleanup before the next console command is accepted. This is installed
+through base R only; it does not inspect or call any package-specific APIs.
 
 Important: the current implementation does not use `GenerateConsoleCtrlEvent`.
 If someone is testing interrupts on Windows, they should validate the current flag-based path, not assume Unix-style `SIGINT` behavior.
@@ -770,6 +786,19 @@ The same high-level state machine exists on both platforms:
 - prompt/input-request events are emitted while waiting
 - output is forwarded through `WriteConsoleEx`
 - dialog requests are bridged back to VS Code
+
+The shared `ReadConsole` state also has a one-shot top-level recovery step.
+After R leaves a busy evaluation, or after nested input returns or is
+interrupted, the next main prompt first consumes a recovery input before any
+queued top-level submit is consumed. Normal returns use a parse-null space.
+Interrupted evaluations use `base::invisible(base::.Last.value)` so the recovery
+turn does not overwrite R's last value while still giving R a clean top-level
+turn. This ports Ark's `ReadConsole` recovery / nested-return concept to the
+host's `run_Rmainloop` model: R gets one clean top-level turn to settle console
+input state, pending warnings, and finalizers before the next user command runs.
+The recovery mode is tracked by the pending recovery enum itself; there is no
+separate stale interrupt-unwind flag. The recovery step is generic and does not
+inspect or special-case any R package.
 
 This means most frontend behavior is platform-independent even though the embedded-R wiring is platform-specific.
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1,680 +1,144 @@
 # Implementation
 
-This document is the current implementation note for `vscode-R-console`.
+This document describes the implementation of `vscode-R-console`.
 
-It is written for another engineer or Codex instance that needs to understand:
+The implementation is centered on four parts:
 
-- what the extension is actually running
-- how the backend is implemented on Unix and Windows
-- how the extension depends on VS Code, `vscode-R`, and `languageserver`
-- what should be tested on Windows
+1. the embedded R backend
+2. the transport model between the backend and the VS Code UI
+3. the `vscode-R` integration layer
+4. the self-managed console session layer
 
-It reflects the current codebase, not older design notes.
+## Implementation References
 
-## 1. True Runtime Model
+These are the main implementation references and the parts of this extension
+they informed. They are references unless the entry explicitly says the project
+is used as a dependency.
 
-The runtime model is:
+| Project | What is referenced or used | Where it appears here |
+| --- | --- | --- |
+| [`vscode-R`](https://github.com/REditorSupport/vscode-R) | Used directly for R executable settings, `R/session/init.R`, watcher files, attach/session metadata, and optional session-server member completion. | `src/Terminal/options.ts`, `resources/r/console-profile.R`, `src/Runtime/sessionWatcher.ts` |
+| [`arf`](https://github.com/eitsupi/arf) | Reference for Rust embedded-R host structure, dynamic R loading, platform-specific R initialization, callback wiring, generic event/input-handler pumping, and interrupt state handling. | `sidecar/pty-host/src/host.rs` |
+| [Ark](https://github.com/posit-dev/ark) | Reference for native R frontend concepts, `ReadConsole` recovery after interrupts/nested input, nested-input separation, and generic R event/finalizer pumping while waiting for input. | `sidecar/pty-host/src/host.rs` |
+| [`rchitect`](https://github.com/randy3k/rchitect) | Reference for embedding R from a non-R host process, R home/shared-library discovery, and callback/FFI boundary patterns. | `sidecar/pty-host/src/host.rs`, `src/Terminal/options.ts` |
+| [`radian`](https://github.com/randy3k/radian) | Reference for terminal-first console interaction, prompt-centric editing, multiline editing, history, reverse search, and bracketed paste expectations. | `src/Terminal/rTerminal.ts` and supporting terminal modules |
+| [`languageserver`](https://github.com/REditorSupport/languageserver) | Used directly as the R language server package for completion, signature help, semantic tokens, and console virtual documents. | `src/Language/consoleLspClient.ts`, `resources/r/console-language-server.R` |
 
-1. VS Code hosts the extension.
-2. The extension creates a custom pseudoterminal implemented by `RTerminal`.
-3. `RTerminal` starts one bundled Rust binary: `R_CONSOLE_HOST`.
-4. `R_CONSOLE_HOST` embeds R directly in-process.
-5. The TypeScript side and the Rust side communicate over a framed protocol carried on stdio.
-6. `vscode-R` is still required for startup/bootstrap/session-watcher integration.
-7. `languageserver` is started in a separate R process for completion, signatures, and semantic tokens.
+No Ark, arf, radian, or rchitect source files are vendored into this repository.
+The embedded backend, protocol, and terminal frontend are local
+implementations adapted from those ideas.
 
-Important correction:
+## 1. Embedded Backend
 
-- `R_CONSOLE_HOST` is not a wrapper around a second internal session-host process.
-- The sidecar process is the embedded host.
+The embedded backend is the Rust sidecar binary:
 
-### 1.1 Integration summary
-
-This extension sits between VS Code, `vscode-R`, and `languageserver` rather than replacing them.
-
-`vscode-R` integration:
-
-- provides the configured `r.rpath.*` executable that R Console prefers at startup
-- provides `R/session/init.R`, which is required for bootstrap
-- provides the watcher/session-server files under `VSCODE_WATCHER_DIR`
-- provides the session state used for search-path updates, workspace/global-environment data, and `$` / `@` member completion
-
-`languageserver` integration:
-
-- runs in a separate R process started by `resources/r/console-language-server.R`
-- receives console-scoped virtual `r-console://` documents from the extension
-- provides completion, signature help, and semantic tokens for the console buffer
-- receives synchronized attached-package and loaded-namespace state from the active session
-- has diagnostics disabled for console buffers, and cleans up virtual documents on close
-
-VS Code integration:
-
-- hosts the extension entrypoint and the custom pseudoterminal lifecycle
-- provides terminal, tab, dialog, workspace-trust, and color-theme events used by the console
-- remains the UI layer, while `vscode-R` and `languageserver` provide R-specific bootstrap and language intelligence
-
-## 2. Packaging And Installed Binaries
-
-The repo only stages one sidecar binary into `bundled/bin/` at a time, but Marketplace/release packaging is target-specific.
-
-Current target-specific VSIX targets are:
-
-- `win32-x64`
-- `win32-arm64`
-- `linux-x64`
-- `linux-arm64`
-- `darwin-x64`
-- `darwin-arm64`
-
-That means:
-
-- a Windows install gets a Windows VSIX containing one Windows sidecar
-- a macOS install gets a macOS VSIX containing one macOS sidecar
-- a Linux install gets a Linux VSIX containing one Linux sidecar
-
-Runtime lookup is simple because the installed package already matches the host:
-
-- Windows: `bundled/bin/R_CONSOLE_HOST.exe`
 - Unix: `bundled/bin/R_CONSOLE_HOST`
+- Windows: `bundled/bin/R_CONSOLE_HOST.exe`
 
-There is no runtime multi-binary chooser inside the installed extension.
+Source files:
 
-## 3. Main Extension Flow
+- [`sidecar/pty-host/src/main.rs`](../sidecar/pty-host/src/main.rs)
+- [`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs)
+- [`sidecar/pty-host/src/protocol.rs`](../sidecar/pty-host/src/protocol.rs)
 
-### 3.1 Terminal creation
+`R_CONSOLE_HOST` embeds R directly in its own process. It is not a wrapper
+around another R terminal process, and it does not start a second session-host
+binary.
 
-The extension entrypoint is [`src/extension.ts`](../src/extension.ts).
+On Windows, `main.rs` uses a launcher mode. The first process starts a detached
+real host process using the same `R_CONSOLE_HOST.exe` binary. The detached
+process is the process that loads R, owns the TCP control server, and owns the
+console session.
 
-When the user runs `r-console.createTerminal` or `r-console.createTerminalSide`:
+### 1.1 Shared Backend State
 
-1. the extension validates trust and workspace constraints
-2. it resolves `RTerminalOptions`
-3. it creates an `RTerminal`
-4. it attaches the pseudoterminal to a VS Code terminal tab
+Both Unix and Windows host modules maintain a shared state object for:
 
-### 3.2 Close / reattach behavior
+- queued top-level submissions
+- queued nested replies
+- parse-status requests
+- dialog results
+- pending width changes
+- prompt/wait state
+- busy state
+- interrupt state
+- shutdown state
+- top-level recovery state
 
-VS Code does not provide a terminal "before close" hook for custom terminals.
+The backend command reader pushes protocol commands into this state. The R
+callbacks read from the same state when R asks for console input, writes output,
+requests dialogs, or reports busy state.
 
-Current behavior differs slightly between panel terminals and side-editor tabs, but the shutdown model is the same:
+### 1.2 Unix R Loading
 
-1. panel terminals are detected from `onDidCloseTerminal`
-2. side-editor terminals are detected from tab-close events and then resolved back to the same console record by pid
-3. if the R console is still running, the extension immediately reattaches the same `RTerminal` instance to a new terminal tab
-4. it then shows the modal confirmation dialog
-5. if the user confirms close, the backend is shut down
-6. if the user cancels, the reattached terminal remains visible
+The Unix backend lives in the Unix module inside
+[`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs).
 
-This is implemented in [`src/extension.ts`](../src/extension.ts).
+It resolves `R_HOME`, then dynamically loads:
 
-## 4. How The TypeScript Side Starts R
+- Linux: `libR.so`
+- macOS: `libR.dylib`
 
-The relevant entrypoint is [`src/Terminal/options.ts`](../src/Terminal/options.ts).
+The backend loads R symbols with `libloading`. Important symbols include:
 
-### 4.1 R path selection
+- `Rf_initialize_R`
+- `setup_Rmainloop`
+- `run_Rmainloop`
+- `R_ParseVector`
+- `R_tryEval`
+- `R_interrupts_pending`
+- `R_CheckUserInterrupt`
+- `R_ExpandFileName`
+- optional event APIs such as `R_ProcessEvents`, `R_PolledEvents`, and
+  `R_RunPendingFinalizers`
 
-The extension prefers the R executable path from `vscode-R` settings:
+### 1.3 Unix Callback Wiring
 
-- `r.rpath.windows`
-- `r.rpath.mac`
-- `r.rpath.linux`
-
-If `r.rpath.*` is unset, the extension falls back to ambient `R_HOME` by
-resolving `R_HOME/bin/R` (or `R.exe` on Windows). If `R_HOME` is also unset,
-it finally falls back to `R` on `PATH`.
-
-Once an executable is selected, the extension derives `R_HOME` from that
-executable path and passes the derived value into the sidecar environment so
-the embedded host loads the matching shared-library tree from the same
-installation.
-
-### 4.2 Hard dependency on `vscode-R`
-
-This extension depends on `REditorSupport.r`.
-
-It requires the file:
-
-- `REditorSupport.r/R/session/init.R`
-
-If that file is missing, startup is rejected.
-
-This means the console is intentionally coupled to `vscode-R`'s session bootstrap model.
-
-Implementation details:
-
-- [`src/Terminal/options.ts`](../src/Terminal/options.ts) calls `vscode.extensions.getExtension("REditorSupport.r")` and resolves the installed extension path through the VS Code extension host.
-- startup fails early if the extension is not installed or if `R/session/init.R` is missing from that installation
-- the console does not try to reproduce vscode-R bootstrap logic itself; it delegates bootstrap to that `init.R`
-- this is why there is no real standalone mode even though the terminal UI and the embedded host live in this repo
-
-`vscode-R` settings and behaviors consumed directly by this extension:
-
-- `r.rpath.windows`, `r.rpath.mac`, `r.rpath.linux`
-- `r.rterm.option`
-- `r.sessionWatcher`
-- `r.bracketedPaste`
-- `r.alwaysUseActiveTerminal`
-
-How those settings are used in practice:
-
-- `r.rpath.*` selects the R executable that both the embedded host and the console LSP use
-- `r.rterm.option` is sanitized and forwarded, but wrapper-specific flags are removed and incompatible flags such as `--vanilla` / `--no-init-file` are rejected
-- `r.sessionWatcher` controls whether the console watches vscode-R session files and enables session-aware completion/state sync
-- `r.bracketedPaste` controls editor-send / paste behavior compatibility
-- `r.alwaysUseActiveTerminal` influences whether the created R Console grabs focus immediately
-
-### 4.3 Startup environment
-
-The runtime launch environment is assembled in two stages:
-
-1. [`src/Terminal/options.ts`](../src/Terminal/options.ts) builds the shared base environment while resolving startup options
-2. [`src/Terminal/rTerminal/runtime.ts`](../src/Terminal/rTerminal/runtime.ts) adds launch-only values such as the current terminal size and the active console bootstrap script immediately before spawning the sidecar
-
-Base environment values:
-
-- `VSCODE_INIT_R`
-  points to `vscode-R`'s `init.R`
-- `VSCODE_WATCHER_DIR`
-  points to the watcher directory used by `vscode-R`
-- `R_PROFILE_USER_OLD`
-  preserves the user's previous `R_PROFILE_USER`
-- `VSC_R_EXECUTABLE`
-  keeps the original configured R binary path
-- `COLORTERM`
-  is set to `truecolor`
-- `R_CLI_NUM_COLORS`
-  is set to `256`
-- `R_CLI_DYNAMIC`
-  is set to `true`
-
-Launch-time environment values:
-
-- `R_PROFILE_USER`
-  is replaced with this extension's own `console-profile.R`
-- `VSC_R_COLS`
-  initial console width
-- `VSC_R_ROWS`
-  initial row count
-- `VSC_R_SESSION_CWD`
-  workspace cwd when available
-- `VSC_R_EXT`
-  extension install path used to resolve bundled resources
-
-The extension also sets the normal R environment such as `R_HOME`, `R_SHARE_DIR`, `R_INCLUDE_DIR`, `R_DOC_DIR`, `PATH`, and platform-specific loader paths.
-
-`R_HOME` is forced from the selected executable instead of inheriting an
-unrelated outer-process `R_HOME`.
-
-The ANSI and `cli` / `crayon` capability hints are currently env-based rather
-than R-option-based because the embedded host is not a real tty.
-
-### 4.4 `console-profile.R`
-
-[`resources/r/console-profile.R`](../resources/r/console-profile.R) does three important things:
-
-1. it sources the user's original `.Rprofile`
-2. it sources `vscode-R`'s `init.R` via `VSCODE_INIT_R`
-3. it replaces the pager so `file.show()` stays inside the console
-
-This is part of the reason the extension depends on `vscode-R`: the console wants the same session bootstrap/watcher behavior as the normal `vscode-R` workflow.
-
-Implementation details inside `console-profile.R`:
-
-- it temporarily restores the user's original `R_PROFILE_USER` from `R_PROFILE_USER_OLD` before sourcing the user's profile
-- profile lookup order is:
-  `R_PROFILE_USER_OLD` if set, otherwise working-directory `.Rprofile`, otherwise `~/.Rprofile`
-- the working directory is normally the selected workspace folder, so workspace `.Rprofile` is usually preferred over the global user profile when no explicit `R_PROFILE_USER` was present
-- after user profile sourcing, it runs vscode-R bootstrap from `VSCODE_INIT_R` inside `tryCatch(...)` so bootstrap failures are reported but do not crash the whole console session
-- it replaces `options(pager=...)` with a console pager implemented in R so pager navigation stays inside the terminal
-- it locks `options(prompt=...)`, `options(continue=...)`, and `options(menu.graphics=...)` while the console is active so the embedded console prompt contract stays stable
-
-That means `vscode-R` is not just a startup prerequisite. Its bootstrap script is part of the live session model that the console expects to run for every session.
-
-## 5. Runtime Backend Protocol
-
-The TypeScript/Rust boundary is defined in [`src/Runtime/backendProtocol.ts`](../src/Runtime/backendProtocol.ts) and [`sidecar/pty-host/src/protocol.rs`](../sidecar/pty-host/src/protocol.rs).
-
-### 5.1 Transport
-
-- Unix: Rust host stdin receives commands from the extension
-- Windows: the extension writes commands to a dedicated named pipe passed in `VSC_R_BACKEND_COMMAND_PIPE`
-- Rust host stdout carries framed output and control events
-- Rust host stderr is reserved for diagnostic/error text
-
-The protocol frame header is 12 bytes and includes:
-
-- payload length
-- frame kind
-- flags
-- request id
-
-### 5.2 Host capabilities
-
-Current capabilities advertised by the embedded host:
-
-- `control-channel`
-- `shutdown`
-- `session-control`
-- `top-level-submit`
-- `nested-input`
-- `parse-status`
-- `set-width`
-
-### 5.3 Control events sent from Rust to TypeScript
-
-Key events:
-
-- `backend-ready`
-- `host-connected`
-- `child-spawned`
-- `prompt`
-- `busy`
-- `input-request`
-- `input-end`
-- `dialog-request`
-- `output-flush`
-- `parse-status-result`
-- `host-error`
-
-### 5.4 Commands sent from TypeScript to Rust
-
-Key commands:
-
-- `submit`
-- `reply-input`
-- `interrupt`
-- `set-width`
-- `dialog-result`
-- `shutdown`
-
-### 5.5 Why stdout handling matters
-
-The protocol shares stdio with R output, so the sidecar has to keep raw console writes from corrupting protocol frames.
-
-Current behavior:
-
-- Unix duplicates the original stdout fd for protocol output and redirects process stdout to stderr.
-- Windows duplicates the stdout handle for protocol output, then redirects process stdout to stderr as well.
-
-That keeps framed protocol traffic isolated from direct R console writes.
-
-## 6. Terminal Frontend Model
-
-The main terminal implementation is [`src/Terminal/rTerminal.ts`](../src/Terminal/rTerminal.ts).
-
-### 6.1 `RTerminal` responsibilities
-
-`RTerminal` owns:
-
-- input state
-- cursor movement
-- multiline editing
-- history
-- reverse search
-- prompt state
-- submission queueing
-- pseudoterminal writes
-- runtime backend lifecycle
-- reattach/restore behavior
-
-### 6.2 Renderer and long-input viewport
-
-Long live input is not rendered as an unbounded terminal transcript.
-
-Instead:
-
-- the editable input area is rendered through the viewport logic in [`src/Terminal/inputViewport.ts`](../src/Terminal/inputViewport.ts)
-- [`src/Terminal/renderer.ts`](../src/Terminal/renderer.ts) tracks rendered row counts and cursor position inside that viewport
-- the terminal can collapse or window long inputs instead of letting them spill uncontrollably
-
-This matters because earlier duplication bugs came from mismatches between the viewport and submission echo paths.
-
-### 6.3 Submission echo model
-
-Current submit behavior is intentionally simple:
-
-- when the current input is already fully visible and stable, the visible input can be reused
-- otherwise, the live input render is cleared and the submission is echoed once
-- before block splitting, submission normalization strips only true full-line R comment tokens; quoted `#...` text such as `Rcpp::sourceCpp()` headers is preserved
-- the submission echo uses `ConsoleSyntax.snapshotNow(...)`
-- there is no second async restyle/rewrite pass for submitted code
-
-This is the current fix for the long-code duplication regressions.
-
-## 7. Screen And Scrollback Restoration
-
-The reattach model changed materially.
-
-Current model:
-
-- every terminal write is mirrored into an off-screen `@xterm/headless` terminal
-- on reattach, the extension serializes that headless terminal buffer back into ANSI text
-- style information is preserved per cell
-- wrapped lines are reassembled into logical lines
-- cursor position is restored after replay
-
-The same replay buffer is also used for resize recovery:
-
-- the viewport and scrollback are cleared first
-- the saved logical lines are replayed at the new width so xterm can wrap them again naturally
-- if the live prompt is visible, it is rendered again after the replay pass
-
-Important related behavior:
-
-- `Ctrl+L` resets the replay terminal itself, not just the visible viewport
-- cleared output therefore stays cleared after both resize and reattach
-
-Relevant implementation:
-
-- [`src/Terminal/rTerminal.ts`](../src/Terminal/rTerminal.ts)
-
-Important consequence:
-
-- reattach restoration is based on a headless terminal buffer, not on a hand-maintained append-only scrollback transcript
-- this is why restored styling now survives reattach
-
-## 8. Syntax Highlighting Model
-
-The console uses a two-layer highlighting model.
-
-### 8.1 Immediate local styling
-
-[`src/Terminal/consoleSyntax.ts`](../src/Terminal/consoleSyntax.ts) applies:
-
-- default theme styling
-- parser-driven token coloring
-- bracket-pair coloring
-
-The tokenizer comes from [`src/Language/parser.ts`](../src/Language/parser.ts).
-
-Important recent change:
-
-- obvious identifier-followed-by-`(` call sites are classified as `function` immediately
-- for example, `plot(1:100)` now highlights `plot` as a function without waiting for semantic tokens
-
-### 8.2 Semantic token overlay
-
-The console then requests semantic tokens from the console-specific language server.
-
-Those semantic tokens are layered on top of the immediate local styles.
-
-This means:
-
-- typing remains responsive even before LSP replies
-- richer semantic styling still arrives when `languageserver` responds
-
-## 9. `languageserver` Integration
-
-The console-specific LSP client lives in:
-
-- [`src/Language/consoleLspClient.ts`](../src/Language/consoleLspClient.ts)
-- [`src/Terminal/rTerminal/lang.ts`](../src/Terminal/rTerminal/lang.ts)
-
-### 9.1 Separate R process
-
-The language server is not hosted inside `R_CONSOLE_HOST`.
-
-It is a separate R process started with:
-
-- the configured R binary
-- `resources/r/console-language-server.R`
-
-Implementation details:
-
-- each `RTerminal` owns one [`RTermLang`](../src/Terminal/rTerminal/lang.ts) instance
-- `RTermLang` lazily creates one [`ConsoleLspClient`](../src/Language/consoleLspClient.ts) per console session
-- the client uses a unique console id and a dedicated temp working directory under the system temp folder
-- the console LSP uses the same resolved `rPath` as the embedded runtime, so language features follow the same R installation as the running console
-
-### 9.2 Transport choice
-
-The LSP transport is:
-
-- stdio only when `r.lsp.use_stdio = true` and the platform is not Windows
-- loopback socket otherwise
-
-Windows uses the socket path, not stdio.
-
-Implementation details:
-
-- the stdio path starts `R` directly through `vscode-languageclient`
-- the socket path first opens a loopback server in the extension host, exports the chosen port through `VSCR_LSP_PORT`, then spawns `R` separately and waits for the language server to connect back
-- Windows always uses the socket path to avoid the stdio/backend interaction problems that the console already has to manage for the embedded host
-- stderr from the spawned LSP process is captured by the client, while normal LSP traffic goes over either stdio or the socket transport
-
-### 9.3 `console-language-server.R`
-
-[`resources/r/console-language-server.R`](../resources/r/console-language-server.R) does the following:
-
-1. adjusts `.libPaths()` using VS Code settings
-2. optionally includes `renv` cache paths
-3. verifies that the `languageserver` package is installed
-4. starts `languageserver`
-5. overrides `textDocument/semanticTokens/full` with a synchronous helper
-6. disables diagnostics for console-only buffers
-7. overrides `textDocument/didClose` so `r-console://` documents are removed cleanly even though they have no filesystem path
-8. adds a custom request:
-   `rConsole/syncSessionState`
-
-Implementation details:
-
-- the script extends `.libPaths()` from `VSCR_LIB_PATHS` and optionally from `renv::paths$cache()` when `VSCR_USE_RENV_LIB_PATH` is enabled
-- it exits with status code `10` when `languageserver` is missing; the TypeScript client treats that as the "package not installed" signal and warns the user
-- it applies `languageserver` option-derived settings, then forces diagnostics off for console buffers
-- it replaces `textDocument/semanticTokens/full` with a synchronous helper so the console can request semantic tokens deterministically for its virtual documents
-- it special-cases `textDocument/didClose` because the console uses `r-console://...` virtual URIs rather than real workspace files
-- it accepts console session state from the extension and pushes attached packages / loaded namespaces into the server workspace so completion and semantic context reflect the live console session more closely
-
-### 9.4 Session-state sync
-
-The extension sends session state to the console LSP:
-
-- attached packages
-- loaded namespaces
-
-That lets the LSP side know more about the live console session than a plain static text document would.
-
-Implementation details:
-
-- [`RTermLang`](../src/Terminal/rTerminal/lang.ts) converts `SessionWatcher` workspace data into a `ConsoleLspSessionState`
-- only package and namespace changes trigger a new sync; identical state is ignored
-- [`ConsoleLspClient`](../src/Language/consoleLspClient.ts) sends that state through the custom `rConsole/syncSessionState` request after ensuring the client is running
-- the R-side handler updates `startup_packages`, refreshes loaded-package state, and eagerly loads namespace metadata when possible
-
-### 9.5 Completion sources
-
-Completion is merged from:
-
-- local context heuristics
-- `languageserver`
-- session watcher workspace state
-- live member completion requests through the `vscode-R` session server for `$` and `@`
-
-Implementation details:
-
-- the current console input is mirrored into a long-lived virtual completion document
-- completion requests manually send `textDocument/didOpen` / `didChange` notifications before each request so document state is ordered correctly
-- semantic-token requests use short-lived snapshot virtual documents so one semantic request cannot corrupt the completion document state
-- the completion pipeline prefers `languageserver` and session data, but can fall back to recent console/session identifiers when the language server does not return useful symbols
-- `$` and `@` completions can bypass `languageserver` and go through vscode-R's session server when a live object/member lookup is needed
-
-### 9.6 Error handling and lifecycle
-
-The console LSP is intentionally quiet from the VS Code UI point of view.
-
-Current behavior:
-
-- client connection errors are suppressed as global popups
-- shutdown close messages are suppressed when the console is intentionally disposing the client
-- the client explicitly sends `workspace/didChangeConfiguration` with diagnostics disabled
-- on stop/dispose, the client sends `textDocument/didClose` for all still-synced console documents before tearing the process down
-- if a spawned R language-server process exits with code `10`, the console warns that the `languageserver` package is required
-
-## 10. `vscode-R` Session Watcher Integration
-
-The watcher integration lives in [`src/Runtime/sessionWatcher.ts`](../src/Runtime/sessionWatcher.ts).
-
-### 10.1 What it watches
-
-It watches lock files created by `vscode-R` under `VSCODE_WATCHER_DIR` and
-then reads the corresponding data files:
-
-- root `request.lock`, then reads root `request.log`
-- attached-session `workspace.lock`, then reads session `workspace.json`
-- the attached session directory itself until `workspace.lock` appears for the first time
-
-### 10.2 What it gets from `vscode-R`
-
-From `request.log`:
-
-- attach/detach events
-- R session tempdir
-- session pid
-- optional session server host/port/token
-
-From `workspace.json`:
-
-- search path
-- loaded namespaces
-- global environment summary
-
-Implementation details:
-
-- attach/detach/session metadata are read from `request.log`
-- workspace state is reloaded from `workspace.json` when `workspace.lock` changes
-- if the console does not yet know which session PID it belongs to, it auto-pins to the first fresh attach request it sees
-- once pinned, it ignores attach events from other R sessions so multiple active R sessions do not cross-contaminate console state
-- if vscode-R exposes an HTTP session server, the watcher also stores its host/port/token for later member-completion requests
-
-### 10.3 Why it matters
-
-The watcher is used for:
-
-- scoping a console tab to one R session
-- showing the real attached R pid when available
-- session-aware completion
-- passing package/namespace state to the console LSP
-
-Detailed flow:
-
-1. the console starts the watcher against `~/.vscode-R`
-2. vscode-R writes an attach event to `request.log`
-3. the watcher resolves the session tempdir and switches to that session's `vscode-R` directory
-4. `workspace.lock` changes cause `workspace.json` reloads
-5. workspace data is pushed into the terminal layer
-6. `RTermLang` converts that data into LSP session state
-7. member-completion HTTP requests use the stored session-server host/port/token when available
-
-## 11. Unix Backend Implementation
-
-Unix is implemented in the `unix_host` module inside [`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs).
-
-### 11.1 R library loading
-
-The Unix host:
-
-- resolves `R_HOME`
-- loads `libR.so` on Linux or `libR.dylib` on macOS
-- loads symbols with `libloading`
-
-### 11.2 Callback registration
-
-Unix uses the normal embedded callback globals:
+Unix uses the normal embedded R callback globals:
 
 - `ptr_R_ReadConsole`
 - `ptr_R_WriteConsoleEx`
-- optional `ptr_R_ShowMessage`
-- optional `ptr_R_Busy`
-- optional `ptr_R_Suicide`
-- optional `ptr_R_ChooseFile`
-- optional `ptr_R_EditFile`
-- optional `ptr_R_EditFiles`
-- optional `ptr_R_ProcessEvents`
-- optional `R_PolledEvents`
+- `ptr_R_ShowMessage`
+- `ptr_R_Busy`
+- `ptr_R_Suicide`
+- `ptr_R_ChooseFile`
+- `ptr_R_EditFile`
+- `ptr_R_EditFiles`
+- `ptr_R_ProcessEvents`
+- `R_PolledEvents`
 
 It also sets:
 
 - `R_Outputfile = NULL`
 - `R_Consolefile = NULL`
 
-so callback output is used instead of file-backed output.
+That makes embedded R route console IO through the callback functions instead
+of file-backed console streams.
 
-### 11.3 Initialization
+Unix initialization calls:
 
-Unix initialization uses:
+1. `Rf_initialize_R`
+2. `setup_Rmainloop`
+3. `run_Rmainloop`
 
-- `Rf_initialize_R`
-- `setup_Rmainloop`
-- `run_Rmainloop`
+The backend adds `--interactive` when needed so embedded R is initialized as an
+interactive console.
 
-It marks R as interactive and captures:
+### 1.4 Windows R DLL Loading
 
-- `R_interrupts_pending`
-- `R_CheckUserInterrupt`
-- `R_ExpandFileName`
+The Windows backend lives in the Windows module inside
+[`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs).
 
-### 11.4 Event pump
+It derives or uses `R_HOME`, then locates `R.dll` in this order:
 
-Unix idle/event pumping uses:
-
-- optional `R_ProcessEvents`
-- `R_checkActivity`
-- `R_runHandlers`
-- `R_InputHandlers`
-- optional `R_PolledEvents`
-- optional `R_RunPendingFinalizers`
-
-The host pumps these while waiting in `ReadConsole`. Package event loops are
-serviced only through R's generic event and input-handler APIs; the backend does
-not special-case individual R packages.
-
-### 11.5 Interrupt model
-
-Unix interrupts use both:
-
-- the `R_interrupts_pending` flag
-- a real `SIGINT` to the current process
-
-That combination is what the current Unix backend actually does.
-On the first real top-level `ReadConsole` turn, the host also injects a generic
-base R interrupt calling handler with `globalCallingHandlers()`. That handler
-invokes R's `abort` restart for interrupt conditions, which lets R unwind
-through normal `on.exit` cleanup before the next console command is accepted.
-This is installed through base R only; it does not inspect or call any
-package-specific APIs.
-
-## 12. Windows Backend Implementation
-
-Windows is implemented in the `windows_host` module inside [`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs).
-
-### 12.1 R layout resolution
-
-The Windows host derives `R_HOME` from:
-
-- `R_HOME` if present
-- otherwise the configured R executable path
-
-It then looks for `R.dll` in:
-
-1. `R_HOME/bin/<R_ARCH>` if `R_ARCH` is set
-2. the executable's own parent directory
-3. `R_HOME/bin/x64` on x64 builds
-4. `R_HOME/bin/arm64` on arm64 builds
+1. `R_HOME/bin/<R_ARCH>` when `R_ARCH` is set
+2. the configured R executable directory
+3. `R_HOME/bin/x64`
+4. `R_HOME/bin/arm64`
 5. `R_HOME/bin`
 
-Current intended support is:
-
-- `x64`
-- `arm64`
-- fallback `bin`
-
-Legacy `i386` is not a supported target.
-
-### 12.2 DLL preload order
-
-The Windows host preloads support DLLs from the chosen R DLL directory before loading `R.dll`.
-
-Current order:
+Before loading `R.dll`, the backend preloads support DLLs from the selected R
+DLL directory:
 
 1. `Rgraphapp.dll`
 2. `Rblas.dll`
@@ -682,11 +146,12 @@ Current order:
 4. `Rlapack.dll`
 5. `R.dll`
 
-This is done so dependent DLL resolution works correctly for embedded R and packages.
+This preload order is part of the backend implementation because embedded R and
+some R packages rely on those DLLs resolving from the same R installation.
 
-### 12.3 Windows symbol loading
+### 1.5 Windows Symbol Loading And Initialization
 
-The host loads Windows-specific symbols when present:
+The Windows backend loads Windows-specific R symbols when present:
 
 - `R_DefParams`
 - `R_DefParamsEx`
@@ -700,32 +165,28 @@ The host loads Windows-specific symbols when present:
 - `R_ProcessEvents`
 - `R_RunPendingFinalizers`
 - `CharacterMode`
-- `UserBreak` or fallback `R_interrupts_pending`
+- `UserBreak`
+- fallback `R_interrupts_pending`
 
-### 12.4 Initialization path
+Windows initialization uses `Rstart` instead of the Unix
+`ptr_R_ReadConsole` startup path:
 
-Windows does not use the Unix `ptr_R_ReadConsole` initialization model.
+1. create an `Rstart` struct
+2. initialize defaults through `R_DefParamsEx(..., 0)` or `R_DefParams`
+3. apply command-line options through `cmdlineoptions` and
+   `R_common_command_line` when available
+4. set interactive mode and callback pointers on `Rstart`
+5. set `rhome` and `home`
+6. call `R_SetParams`
+7. wire file/dialog callbacks
+8. call `GA_initapp`
+9. call `readconsolecfg`
+10. switch `CharacterMode` to `LinkDLL`
+11. call `setup_Rmainloop`
 
-Instead it:
+### 1.6 Windows Callback Wiring
 
-1. builds an `Rstart` struct
-2. initializes defaults with `R_DefParamsEx(..., 0)` when available, otherwise `R_DefParams`
-3. optionally calls `cmdlineoptions`
-4. optionally lets `R_common_command_line` fill startup flags from args
-5. sets interactive mode and callback pointers on `Rstart`
-6. sets `rhome` and `home`
-7. calls `R_SetParams`
-8. wires `ptr_R_ChooseFile`, `ptr_R_EditFile`, and `ptr_R_EditFiles` when available
-9. calls `GA_initapp`
-10. calls `readconsolecfg`
-11. switches `CharacterMode` to `LinkDLL`
-12. calls `setup_Rmainloop`
-
-The `home` path is taken from `getRUser()` when possible, with ANSI-codepage decoding fallback.
-
-### 12.5 Windows callbacks
-
-Current Windows callback set includes:
+Windows registers callbacks through the `Rstart` structure:
 
 - `ReadConsole`
 - `WriteConsoleEx`
@@ -738,243 +199,473 @@ Current Windows callback set includes:
 - `EditFile`
 - `EditFiles`
 
-### 12.6 Event pump
+Those callbacks bridge embedded R to the same shared backend state used by the
+Unix implementation.
 
-Windows idle/event pumping is centered on the Windows / graphapp message loop,
-but it does not stop there.
+### 1.7 R Event Loop And Input Handler Pumping
 
-Current behavior:
+The backend does not hardcode package event loops. It only calls generic R and
+platform event APIs.
 
-- the explicit idle pump drains the Windows message queue with `PeekMessageW` / `DispatchMessageW`
-- `R_ProcessEvents()` is called when available
-- optional input handlers still run through `R_checkActivity`, `R_runHandlers`, and `R_InputHandlers` when those symbols are available
-- pending finalizers are run through `R_RunPendingFinalizers()` when available
-- the callback path (`process_events_callback` / `polled_events_callback`) also pumps Windows messages and available handlers
+Unix event pumping uses available symbols such as:
 
-This is what keeps Windows graphapp/help/GUI event processing moving while the console is waiting for input, while still servicing handler-driven work through R's generic event APIs. The backend does not call package-specific event functions.
+- `R_ProcessEvents`
+- `R_checkActivity`
+- `R_runHandlers`
+- `R_InputHandlers`
+- `R_PolledEvents`
+- `R_RunPendingFinalizers`
 
-### 12.7 Interrupt model
+Windows event pumping uses:
 
-Current Windows interrupt handling is flag-based, not signal-based.
+- the Windows message queue through `PeekMessageW` / `DispatchMessageW`
+- `GA_peekevent`
+- `R_ProcessEvents`
+- `R_checkActivity`
+- `R_runHandlers`
+- `R_InputHandlers`
+- `R_RunPendingFinalizers`
 
-The host sets:
+The backend runs these pumps while R is waiting in `ReadConsole` and from the
+registered callback path. Input-handler draining is bounded per pump turn. If
+an interrupt is requested during event processing, the backend preserves the R
+interrupt flag and returns control to R.
+
+### 1.8 ReadConsole State Machine
+
+`ReadConsole` is the main bridge between R and the VS Code UI.
+
+The backend distinguishes:
+
+- top-level console prompts: the locked `> ` and `+ ` prompts
+- nested prompts: every other prompt, including `readline()` and browser-style
+  prompts
+
+Top-level input is supplied from queued `submit` commands. Nested input is
+supplied from queued `reply-input` commands.
+
+While `ReadConsole` is waiting, the backend also handles:
+
+- parse-status requests
+- width changes
+- interrupts
+- shutdown requests
+- dialog results
+- event pumping
+
+After busy evaluation or nested input returns, the backend can insert one
+top-level recovery input before the next user command is consumed. The recovery
+step is implemented in the shared backend state and is generic R console
+handling; it does not inspect individual packages.
+
+### 1.9 Interrupt Implementation
+
+Unix interrupt implementation uses:
+
+- `R_interrupts_pending`
+- `SIGINT` sent to the current process
+- `R_CheckUserInterrupt` where needed
+
+Windows interrupt implementation uses:
 
 - `UserBreak` when exported
 - otherwise `R_interrupts_pending`
+- `R_CheckUserInterrupt` where needed
 
-It also calls `R_CheckUserInterrupt` when needed after interrupted nested reads.
-On the first real top-level `ReadConsole` turn, the host injects a generic base
-R interrupt calling handler with `globalCallingHandlers()`. That handler invokes
-R's `abort` restart for interrupt conditions, which lets R unwind through normal
-`on.exit` cleanup before the next console command is accepted. This is installed
-through base R only; it does not inspect or call any package-specific APIs.
+Both platforms install a base R interrupt calling handler on the first real
+top-level console read. That handler uses R's `abort` restart so R can unwind
+through normal cleanup paths.
 
-Important: the current implementation does not use `GenerateConsoleCtrlEvent`.
-If someone is testing interrupts on Windows, they should validate the current flag-based path, not assume Unix-style `SIGINT` behavior.
+Windows does not use `GenerateConsoleCtrlEvent`.
 
-## 13. Shared Backend Logic Between Unix And Windows
+## 2. Transport Model Between Backend And UI
 
-Although initialization differs per platform, most host-control logic is shared conceptually.
+TypeScript transport implementation:
 
-The same high-level state machine exists on both platforms:
+- [`src/Runtime/runtimeBackend.ts`](../src/Runtime/runtimeBackend.ts)
+- [`src/Runtime/backendProtocol.ts`](../src/Runtime/backendProtocol.ts)
 
-- command reader thread reads backend frames from stdin on Unix or the backend named pipe on Windows
-- commands are queued in shared state
-- `ReadConsole` waits for top-level submits or nested replies
-- parse-status requests are handled while waiting
-- width changes are handled while waiting
-- prompt/input-request events are emitted while waiting
-- output is forwarded through `WriteConsoleEx`
-- dialog requests are bridged back to VS Code
+Rust transport implementation:
 
-The shared `ReadConsole` state also has a one-shot top-level recovery step.
-After R leaves a busy evaluation, or after nested input returns or is
-interrupted, the next main prompt first consumes a recovery input before any
-queued top-level submit is consumed. Normal returns use a parse-null space.
-Interrupted evaluations use `base::invisible(base::.Last.value)` so the recovery
-turn does not overwrite R's last value while still giving R a clean top-level
-turn. This ports Ark's `ReadConsole` recovery / nested-return concept to the
-host's `run_Rmainloop` model: R gets one clean top-level turn to settle console
-input state, pending warnings, and finalizers before the next user command runs.
-The recovery mode is tracked by the pending recovery enum itself; there is no
-separate stale interrupt-unwind flag. The recovery step is generic and does not
-inspect or special-case any R package.
+- [`sidecar/pty-host/src/protocol.rs`](../sidecar/pty-host/src/protocol.rs)
+- the session command reader in [`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs)
 
-This means most frontend behavior is platform-independent even though the embedded-R wiring is platform-specific.
+### 2.1 Session Startup Transport
 
-One important shared contract is prompt classification:
+When a console starts, `RustSidecarRuntimeBackend.start(...)`:
 
-- only the locked console prompts `> ` and `+ ` are treated as top-level prompts
-- everything else, including history-enabled prompts such as `Browse[1]>`, is treated as nested input
+1. creates a UUID session id
+2. creates a per-session bootstrap file path
+3. spawns `R_CONSOLE_HOST`
+4. passes `VSC_R_BACKEND_SESSION_FILE` to the backend
+5. passes initial connect and reconnect grace values
+6. detaches/unrefs the process from the VS Code extension host
 
-That shared rule is why `browser()`, pager prompts, and other nested reads now behave consistently on both Unix and Windows.
+The Rust host reads `VSC_R_BACKEND_SESSION_FILE`, binds a TCP listener on
+`127.0.0.1:0`, then writes JSON to the bootstrap file:
 
-## 14. Recent Backend-Adjacent Fixes
+```json
+{"port":12345,"pid":67890}
+```
 
-These are important for Windows testing because they changed expected behavior.
+The TypeScript side polls that file, reads the port and pid, then connects to
+the loopback server.
 
-### 14.1 Long-input duplication fix
+### 2.2 Reconnect Transport
 
-Recent fixes removed the bad async submission-restyle model.
+Reconnect uses `RuntimeSessionReconnectInfo`:
 
-Current expected behavior:
+- `sessionId`
+- `port`
+- `pid`
 
-- long live input is clipped/windowed in the editable viewport
-- submitted code is echoed once
-- no duplicated top rows
-- no extra leading `R>`
+`RustSidecarRuntimeBackend.reconnect(...)` creates a new
+`RuntimeSessionHandle` around that information. It does not spawn a new R
+backend. It connects to the existing loopback TCP server.
 
-### 14.2 Reattach restore fix
+The runtime checks process liveness before reconnecting:
 
-Reattach now restores:
+- if the recorded backend pid is dead, the reconnect info is discarded
+- if the Windows launcher process has exited but the detached real host pid is
+  alive, reconnect continues
 
-- scrollback
-- current visible screen
-- cursor position
-- ANSI styling
+### 2.3 Active Client Model
 
-Expected behavior after cancelling a close:
+The Rust backend accepts one active control client at a time.
 
-- the console should look materially identical to before the close attempt
+Implementation details:
 
-### 14.3 Immediate function-call coloring
+- each accepted socket receives a client id
+- `current_client` stores the currently active id
+- a new socket replaces the previous active socket
+- command-reader threads exit when their client id is no longer current
+- output is attached to the active client writer
+- when the active client disconnects, output is detached and the reconnect
+  grace timer is applied
 
-`plot(1:100)` should color `plot` as a function immediately, even if the user submits quickly.
+This is how a console tab can detach and another UI instance can attach to the
+same embedded R backend.
 
-### 14.4 Resize replay and hard clear
+### 2.4 Framed Protocol
 
-Recent terminal fixes changed both resize recovery and clear-screen semantics.
+The protocol frame header is 12 bytes:
 
-Current expected behavior:
+- payload length
+- frame kind
+- flags
+- request id
 
-- terminal resize rebuilds the visible console from the headless replay buffer
-- wrapped output is reflowed at the new width instead of replaying already-wrapped old rows
-- empty prompt-only submits keep the visible `R> ` line after resize
-- `Ctrl+L` clears the current viewport and also drops the replay buffer, so old content does not reappear later
+Backend events sent to TypeScript include:
 
-### 14.5 Console completion and LSP cleanup
+- `backend-ready`
+- `host-connected`
+- `session-state`
+- `prompt`
+- `busy`
+- `input-request`
+- `input-end`
+- `dialog-request`
+- `output-flush`
+- `parse-status-result`
+- `host-error`
 
-Recent console-language changes also affect what users should expect.
+Commands sent to Rust include:
 
-Current expected behavior:
+- `submit`
+- `reply-input`
+- `interrupt`
+- `set-width`
+- `dialog-result`
+- `shutdown`
 
-- completion still prefers `languageserver` and session watcher data
-- when those sources are missing, recent console identifiers can still appear as fallback suggestions
-- console diagnostics are disabled
-- closing a console-scoped `r-console://` virtual document should not leave stale LSP workspace state behind
+Host capabilities are advertised through `backend-ready`:
 
-## 15. Windows Testing Checklist
+- `control-channel`
+- `shutdown`
+- `session-control`
+- `top-level-submit`
+- `nested-input`
+- `parse-status`
+- `set-width`
 
-This is the minimum useful Windows validation list.
+### 2.5 Output Channel
 
-### 15.1 Installation / packaging
+Rust emits console output and control events through the active protocol writer.
+If no client is attached, `protocol.rs` queues frames in an output backlog.
 
-- install the correct target-specific VSIX for the machine
-- confirm the installed extension contains one correct sidecar:
-  `bundled/bin/R_CONSOLE_HOST.exe`
-- confirm `REditorSupport.r` is installed
-- confirm the startup resolution source points to the intended R install:
-  `r.rpath.*`, else ambient `R_HOME`, else `PATH`
+The backlog is bounded by:
 
-### 15.2 Startup
+- maximum buffered frames
+- maximum buffered bytes
 
-- create a console from the command palette
-- confirm the sidecar starts cleanly
-- confirm the prompt appears
-- confirm the terminal title eventually shows the attached R pid
-- confirm startup still works with `r.sessionWatcher` enabled
+When a client attaches, the backend:
 
-### 15.3 Console editing and submission
+1. attaches the socket writer
+2. flushes the backlog
+3. emits `backend-ready`
+4. emits `host-connected`
+5. emits `session-state`
+6. emits `output-flush`
 
-- single-line commands
-- multi-line functions
-- very long functions that exceed the visible input viewport
-- history navigation through long commands
-- reverse search
-- bracketed paste
-- parse completeness gating
+### 2.6 Shutdown Transport
 
-Expected:
+Attached sessions close by writing a `shutdown` frame over the active socket.
 
-- no duplicated top rows
-- no duplicate `R>`
-- no second rewritten copy of the same submitted block
+Detached sessions close by:
 
-### 15.4 Highlighting and language features
+1. constructing a temporary runtime backend in the extension host
+2. reconnecting to the stored `sessionId` / `port` / `pid`
+3. writing the same `shutdown` frame
 
-- local highlighting while typing
-- immediate function-call highlighting for `foo(...)`
-- semantic highlighting after LSP response
-- completions from `languageserver`
-- signature help
-- `$` / `@` member completion backed by the session server
+The Rust command reader maps `shutdown` to the backend shared shutdown state.
 
-### 15.5 `vscode-R` integration
+## 3. `vscode-R` Integration
 
-- confirm `vscode-R` bootstrap still runs
-- confirm session watcher updates search path and global env
-- confirm attached packages / namespaces reach the console LSP
-- confirm `file.show()` stays inside the console pager instead of spawning the external pager
+The console depends on `vscode-R`, but it does not own or manage the
+`vscode-R` session.
 
-### 15.6 Windows-specific backend behavior
+Implementation files:
 
-- `plot()` responsiveness
-- help/browser/graphapp responsiveness while waiting for input
-- interrupt during long-running computation
-- nested input (`readline()`, browser-like prompts, pager prompts)
-- `file.choose()`
-- `edit()`
-- `file.edit()`
-- `system()` and `system2()`
+- [`src/Terminal/options.ts`](../src/Terminal/options.ts)
+- [`resources/r/console-profile.R`](../resources/r/console-profile.R)
+- [`src/Runtime/sessionWatcher.ts`](../src/Runtime/sessionWatcher.ts)
 
-### 15.7 Reattach / close behavior
+### 3.1 Startup Settings From `vscode-R`
 
-- close the terminal tab
-- confirm it immediately reattaches before the modal dialog
-- cancel close and verify the full screen is still there
-- verify syntax coloring survives reattach
-- confirm scrollback and cursor restoration are sane
+R executable selection reads the `vscode-R` settings:
 
-## 16. Useful Failure Signals
+- `r.rpath.windows`
+- `r.rpath.mac`
+- `r.rpath.linux`
 
-When Windows testing fails, check these in order:
+If those are unset, the console falls back to ambient `R_HOME`, then `R` on
+`PATH`.
 
-1. VS Code terminal output for startup failure text
-2. the console LSP output channel
-3. whether `R_CONSOLE_HOST.exe` exists in the installed extension
-4. whether `vscode-R` is installed and its `R/session/init.R` exists
-5. whether the resolved runtime source really points at the intended R install
-6. whether `R.dll` and support DLLs exist in the expected `bin/x64`, `bin/arm64`, or `bin` directory
+The selected executable is used to derive:
 
-Typical failure classes:
+- `R_HOME`
+- `R_SHARE_DIR`
+- `R_INCLUDE_DIR`
+- `R_DOC_DIR`
+- platform loader paths
 
-- missing sidecar package for the current target
-- missing `vscode-R`
-- wrong runtime selection from `r.rpath.*`, ambient `R_HOME`, or `PATH`
-- bad Windows R layout resolution
-- missing support DLL preload
-- no `languageserver`
-- session watcher not attaching
+The same selected R executable is used for:
 
-## 17. Current Assumptions And Limits
+- the embedded backend
+- the console `languageserver` process
 
-- The console depends on `vscode-R`; there is no standalone mode.
-- Windows support is for modern 64-bit layouts only.
-- The Windows LSP path uses a socket transport, not stdio.
-- Close interception is still constrained by the VS Code custom-terminal API.
+### 3.2 Startup Bootstrap From `vscode-R`
 
-## 18. Files To Read First
+The console requires:
 
-If another Codex needs to continue work, start with these files in this order:
+- `REditorSupport.r/R/session/init.R`
+
+`options.ts` resolves the installed `REditorSupport.r` extension path through
+the VS Code extension API. Startup is rejected if `init.R` is missing.
+
+The backend launch environment includes:
+
+- `VSCODE_INIT_R`
+- `VSCODE_WATCHER_DIR`
+- `R_PROFILE_USER_OLD`
+- `VSC_R_EXECUTABLE`
+
+At launch time, `rTerminal/runtime.ts` also sets:
+
+- `R_PROFILE_USER` to this extension's `console-profile.R`
+- `VSC_R_COLS`
+- `VSC_R_ROWS`
+- `VSC_R_SESSION_CWD`
+- `VSC_R_EXT`
+
+`console-profile.R` then:
+
+1. restores and sources the user's original profile through
+   `R_PROFILE_USER_OLD`
+2. sources `VSCODE_INIT_R`
+3. installs the console pager
+4. locks the prompt options used by the embedded console contract
+
+### 3.3 Session Watcher Metadata
+
+`SessionWatcher` reads files produced by `vscode-R` under
+`VSCODE_WATCHER_DIR`.
+
+It watches:
+
+- root `request.lock`
+- root `request.log`
+- session `workspace.lock`
+- session `workspace.json`
+- the attached session directory until workspace state appears
+
+From `request.log`, it reads:
+
+- attach/detach commands
+- R session tempdir
+- R session pid
+- optional session server host/port/token
+
+From `workspace.json`, it reads:
+
+- search path
+- loaded namespaces
+- global environment summary
+
+The watcher can auto-pin to the first fresh attach event when the backend pid is
+not known yet. Once pinned, it ignores attach events from other R sessions.
+
+### 3.4 Metadata Consumers
+
+The console consumes watcher metadata for:
+
+- display pid selection
+- search-path aware completion
+- global-environment completion
+- `$` and `@` member completion through the `vscode-R` session server when
+  available
+- attached package and namespace sync into the console LSP
+
+This integration is read-only with respect to `vscode-R` sessions. The console
+does not create, replace, restore, or stop `vscode-R` sessions.
+
+## 4. Self-managed Console
+
+Self-managed console implementation is split between:
+
+- [`src/extension.ts`](../src/extension.ts)
+- [`src/Terminal/rTerminal.ts`](../src/Terminal/rTerminal.ts)
+- [`src/Runtime/runtimeBackend.ts`](../src/Runtime/runtimeBackend.ts)
+
+The self-managed console is the extension's own embedded backend session. It is
+separate from the `vscode-R` session watcher.
+
+### 4.1 Runtime Session Handles
+
+`runtimeBackend.ts` exposes:
+
+- `start(args, options)`
+- `reconnect(info)`
+- `attach(session, handlers)`
+- `sendSessionCommand(session, command)`
+- `requestParseStatus(session, code)`
+- `close(session)`
+- `isAlive(session)`
+- `getPid(session)`
+- `getReconnectInfo(session)`
+
+`RTerminal` stores the returned `RuntimeSessionHandle` as its backend session.
+The handle is used for all protocol commands and for exporting reconnect state.
+
+### 4.2 Persisted Console Records
+
+The extension stores self-managed console records in:
+
+- `persistent-sessions.json`
+
+The file is stored under extension storage:
+
+- `context.storageUri` when available
+- otherwise `context.globalStorageUri`
+
+Each record contains:
+
+- runtime reconnect info: session id, port, pid
+- persisted terminal options: R path, R args, watcher settings, bracketed paste,
+  cwd
+- UI replay state: replay buffer, dimensions, mode, prompt state, input text,
+  cursor position, backend pid
+- terminal location: panel or editor column
+
+The persisted data belongs to R Console. It is not a `vscode-R` session
+snapshot.
+
+### 4.3 Registry Loading And Pruning
+
+On activation, `extension.ts` loads:
+
+- `persistent-sessions.json`
+- legacy `reload-sessions.json`
+
+Records are validated before use. A record is kept only when:
+
+- its runtime reconnect info is structurally valid
+- its terminal options are structurally valid
+- its UI replay state is structurally valid
+- its recorded backend pid is either absent or still alive
+
+Dead records are removed from the in-memory registry and the persisted file is
+rewritten.
+
+### 4.4 Creating A Console
+
+Creating a console follows this implementation path:
+
+1. `createRTerminal(...)` resolves `RTerminalOptions`
+2. `new RTerminal(...)` creates the terminal controller
+3. `attachTerminal(...)` creates a VS Code pseudoterminal
+4. `RTerminal` calls the runtime backend to start a session
+5. `runtimeBackend.ts` starts `R_CONSOLE_HOST`
+6. the backend writes the bootstrap file
+7. TypeScript connects to the loopback server
+8. backend events update terminal state
+9. the extension schedules persistence of the session record
+
+### 4.5 Attaching A Detached Console
+
+Attaching a detached console follows this implementation path:
+
+1. the session manager reads the persisted record
+2. `buildPersistentTerminalOptions(...)` combines current resolved options with
+   persisted options
+3. `new RTerminal(options, extensionPath, persistedState)` rebuilds the frontend
+4. the persisted runtime reconnect info is passed to `runtimeBackend.reconnect`
+5. TypeScript connects to the existing backend socket
+6. the terminal replay state is used to rebuild the visible terminal
+
+No new embedded R backend is started for a reconnect.
+
+### 4.6 Closing A Managed Console
+
+Attached console close uses the active `RTerminal` and active runtime session.
+
+Detached console close uses the persisted reconnect info:
+
+1. create a runtime backend object
+2. call `reconnect(...)` with the persisted runtime info
+3. call `close(...)`
+4. remove the persistent registry record
+
+The close command targets the R Console backend socket. It does not send any
+command to `vscode-R`.
+
+### 4.7 Persistence Updates
+
+The extension persists console records:
+
+- after console creation
+- after attach/detach state changes
+- after terminal title/pid updates
+- on a debounce timer
+- on a heartbeat timer
+- during extension shutdown
+
+`RTerminal.exportPersistentState()` is the source of the persisted runtime and
+UI state. If the runtime backend cannot provide reconnect info, the terminal is
+not persisted.
+
+## 5. Files To Read First
 
 1. [`src/extension.ts`](../src/extension.ts)
-2. [`src/Terminal/options.ts`](../src/Terminal/options.ts)
-3. [`src/Terminal/rTerminal.ts`](../src/Terminal/rTerminal.ts)
-4. [`src/Terminal/rTerminal/runtime.ts`](../src/Terminal/rTerminal/runtime.ts)
-5. [`src/Runtime/backendProtocol.ts`](../src/Runtime/backendProtocol.ts)
-6. [`src/Runtime/sessionWatcher.ts`](../src/Runtime/sessionWatcher.ts)
-7. [`src/Language/consoleLspClient.ts`](../src/Language/consoleLspClient.ts)
+2. [`src/Runtime/runtimeBackend.ts`](../src/Runtime/runtimeBackend.ts)
+3. [`src/Runtime/backendProtocol.ts`](../src/Runtime/backendProtocol.ts)
+4. [`src/Terminal/rTerminal.ts`](../src/Terminal/rTerminal.ts)
+5. [`src/Terminal/rTerminal/runtime.ts`](../src/Terminal/rTerminal/runtime.ts)
+6. [`src/Terminal/options.ts`](../src/Terminal/options.ts)
+7. [`src/Runtime/sessionWatcher.ts`](../src/Runtime/sessionWatcher.ts)
 8. [`resources/r/console-profile.R`](../resources/r/console-profile.R)
-9. [`resources/r/console-language-server.R`](../resources/r/console-language-server.R)
+9. [`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs)
 10. [`sidecar/pty-host/src/protocol.rs`](../sidecar/pty-host/src/protocol.rs)
-11. [`sidecar/pty-host/src/host.rs`](../sidecar/pty-host/src/host.rs)
+11. [`sidecar/pty-host/src/main.rs`](../sidecar/pty-host/src/main.rs)
+12. [`src/Language/consoleLspClient.ts`](../src/Language/consoleLspClient.ts)
+13. [`resources/r/console-language-server.R`](../resources/r/console-language-server.R)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-r-console",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-r-console",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/headless": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-r-console",
   "displayName": "R Console",
   "description": "A lightweight R console for VS Code",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "RConsole",
   "license": "MIT",
   "icon": "images/Rlogo.png",

--- a/package.json
+++ b/package.json
@@ -63,12 +63,17 @@
       {
         "command": "r-console.createTerminal",
         "title": "Create R Console",
-        "category": "R"
+        "category": "R Console"
       },
       {
         "command": "r-console.createTerminalSide",
         "title": "Create R Console in Side Editor",
-        "category": "R"
+        "category": "R Console"
+      },
+      {
+        "command": "r-console.managePersistentSessions",
+        "title": "Manage Persistent Sessions...",
+        "category": "R Console"
       }
     ],
     "configuration": {

--- a/sidecar/pty-host/Cargo.lock
+++ b/sidecar/pty-host/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "R_CONSOLE_HOST"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libc",
  "libloading",

--- a/sidecar/pty-host/Cargo.lock
+++ b/sidecar/pty-host/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "R_CONSOLE_HOST"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "libc",
  "libloading",

--- a/sidecar/pty-host/Cargo.toml
+++ b/sidecar/pty-host/Cargo.toml
@@ -13,8 +13,10 @@ libloading = "0.8"
 windows-sys = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_Globalization",
+  "Win32_Security",
   "Win32_System_Console",
   "Win32_System_LibraryLoader",
+  "Win32_System_Pipes",
   "Win32_System_Threading",
   "Win32_UI_WindowsAndMessaging",
 ] }

--- a/sidecar/pty-host/Cargo.toml
+++ b/sidecar/pty-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "R_CONSOLE_HOST"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/sidecar/pty-host/Cargo.toml
+++ b/sidecar/pty-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "R_CONSOLE_HOST"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]

--- a/sidecar/pty-host/build.rs
+++ b/sidecar/pty-host/build.rs
@@ -9,7 +9,11 @@ fn main() {
     }
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
-    let icon_path = manifest_dir.join("..").join("..").join("images").join("Rlogo.ico");
+    let icon_path = manifest_dir
+        .join("..")
+        .join("..")
+        .join("images")
+        .join("Rlogo.ico");
     println!("cargo:rerun-if-changed={}", icon_path.display());
 
     let mut res = winresource::WindowsResource::new();

--- a/sidecar/pty-host/src/host.rs
+++ b/sidecar/pty-host/src/host.rs
@@ -9,8 +9,8 @@ pub(crate) fn run(_args: Vec<String>) -> Result<(), Box<dyn Error>> {
 #[cfg(unix)]
 mod unix_host {
     use crate::protocol::{
-        read_next_command, DialogRequest, DialogResult, IncomingCommand, OutputSink,
-        OutputStream, PromptKind,
+        read_next_command, DialogRequest, DialogResult, IncomingCommand, OutputSink, OutputStream,
+        PromptKind,
     };
     use libloading::os::unix::{Library, Symbol};
     use std::collections::VecDeque;
@@ -48,7 +48,8 @@ mod unix_host {
     type RfInitializeR = unsafe extern "C" fn(c_int, *mut *mut c_char) -> c_int;
     type SetupRMainloop = unsafe extern "C" fn();
     type RunRMainloop = unsafe extern "C" fn();
-    type ReadConsoleFn = unsafe extern "C" fn(*const c_char, *mut c_uchar, c_int, c_int) -> c_int;
+    type ReadConsoleFn =
+        unsafe extern "C-unwind" fn(*const c_char, *mut c_uchar, c_int, c_int) -> c_int;
     type WriteConsoleFn = unsafe extern "C" fn(*const c_char, c_int);
     type WriteConsoleExFn = unsafe extern "C" fn(*const c_char, c_int, c_int);
     type ShowMessageFn = unsafe extern "C" fn(*const c_char);
@@ -62,9 +63,11 @@ mod unix_host {
         *const *const c_char,
         *const c_char,
     ) -> c_int;
-    type EventCallbackFn = unsafe extern "C" fn();
+    type EventCallbackFn = unsafe extern "C-unwind" fn();
     type ExpandFileNameFn = unsafe extern "C" fn(*const c_char) -> *const c_char;
     type CheckUserInterruptFn = unsafe extern "C" fn();
+    type ProcessEventsFn = unsafe extern "C" fn();
+    type RunPendingFinalizersFn = unsafe extern "C" fn();
     type CheckActivityFn = unsafe extern "C" fn(c_int, c_int) -> *mut libc::fd_set;
     type RunHandlersFn = unsafe extern "C" fn(*mut c_void, *mut libc::fd_set);
     type Sexp = *mut c_void;
@@ -105,6 +108,8 @@ mod unix_host {
         r_running_as_main_program: Option<*mut c_int>,
         r_interrupts_pending: Option<*mut c_int>,
         r_check_user_interrupt: Option<CheckUserInterruptFn>,
+        r_process_events: Option<ProcessEventsFn>,
+        r_run_pending_finalizers: Option<RunPendingFinalizersFn>,
         r_check_activity: CheckActivityFn,
         r_run_handlers: RunHandlersFn,
         r_input_handlers: *mut *mut c_void,
@@ -138,10 +143,19 @@ mod unix_host {
         pending_dialog_result: Option<DialogResult>,
         pending_width: Option<u16>,
         current_width: Option<u16>,
+        startup_input_pending: bool,
         busy: bool,
         interrupt_requested: bool,
         suppress_idle_event_pump: bool,
+        top_level_recovery_pending: Option<TopLevelRecovery>,
+        top_level_recovery_active: bool,
         shutdown_requested: bool,
+    }
+
+    #[derive(Clone, Copy)]
+    enum TopLevelRecovery {
+        ParseNull,
+        RecoverFromInterrupt,
     }
 
     enum PendingCommand {
@@ -187,6 +201,8 @@ mod unix_host {
 
     #[derive(Clone, Copy)]
     struct EventLoopApi {
+        r_process_events: Option<ProcessEventsFn>,
+        r_run_pending_finalizers: Option<RunPendingFinalizersFn>,
         r_check_activity: CheckActivityFn,
         r_run_handlers: RunHandlersFn,
         r_toplevel_exec: TopLevelExecFn,
@@ -204,6 +220,8 @@ mod unix_host {
         width: c_int,
         success: bool,
     }
+
+    const STARTUP_INTERRUPT_HANDLER_INPUT: &str = r#"base::local({ if (base::getRversion() >= "4.0.0") { handler <- function(e) { restart <- base::findRestart("abort"); if (!base::is.null(restart)) base::invokeRestart(restart) }; handlers <- base::globalCallingHandlers(); base::globalCallingHandlers(NULL); handlers <- c(handlers, list(interrupt = handler)); base::do.call(base::globalCallingHandlers, handlers) }; base::invisible(NULL) }, envir = base::new.env(parent = base::baseenv()))"#;
 
     struct PumpEventsContext {
         api: EventLoopApi,
@@ -225,7 +243,10 @@ mod unix_host {
         HOST_RUNTIME
             .set(HostRuntime {
                 output: output.clone_handle(),
-                state: Mutex::new(SharedState::default()),
+                state: Mutex::new(SharedState {
+                    startup_input_pending: true,
+                    ..SharedState::default()
+                }),
                 cv: Condvar::new(),
             })
             .map_err(|_| "host runtime already initialized")?;
@@ -356,6 +377,7 @@ mod unix_host {
         if let Some(runtime) = host_runtime() {
             let mut state = runtime.state.lock().expect("host state lock poisoned");
             state.interrupt_requested = true;
+            state.top_level_recovery_pending = Some(TopLevelRecovery::RecoverFromInterrupt);
             should_signal = state.busy;
             runtime.cv.notify_all();
         }
@@ -521,8 +543,6 @@ mod unix_host {
             return;
         };
 
-        set_r_interrupts_pending(false);
-
         let mut context = PumpEventsContext { api };
         unsafe {
             (api.r_toplevel_exec)(
@@ -532,21 +552,27 @@ mod unix_host {
         }
     }
 
-    unsafe fn run_input_handlers(api: EventLoopApi) {
+    unsafe fn run_process_events(api: EventLoopApi) {
+        if let Some(process_events) = api.r_process_events {
+            process_events();
+        }
+        run_activity_handlers(api);
+        if let Some(run_pending_finalizers) = api.r_run_pending_finalizers {
+            run_pending_finalizers();
+        }
+    }
+
+    unsafe fn run_activity_handlers(api: EventLoopApi) {
         let handlers = *(api.r_input_handlers as *mut *mut c_void);
         if handlers.is_null() {
             return;
         }
 
-        let mask = (api.r_check_activity)(0, 1);
-
-        #[cfg(target_os = "macos")]
-        if !mask.is_null() {
+        let mut mask = (api.r_check_activity)(0, 1);
+        while !mask.is_null() {
             (api.r_run_handlers)(handlers, mask);
+            mask = (api.r_check_activity)(0, 1);
         }
-
-        #[cfg(not(target_os = "macos"))]
-        (api.r_run_handlers)(handlers, mask);
     }
 
     unsafe extern "C" fn execute_pump_events(data: *mut c_void) {
@@ -555,26 +581,26 @@ mod unix_host {
         }
 
         let context = &mut *(data as *mut PumpEventsContext);
-        run_input_handlers(context.api);
+        run_process_events(context.api);
     }
 
-    unsafe extern "C" fn process_events_callback() {
+    unsafe extern "C-unwind" fn process_events_callback() {
         let Some(api) = event_loop_api() else {
             return;
         };
 
-        run_input_handlers(api);
+        run_activity_handlers(api);
     }
 
-    unsafe extern "C" fn polled_events_callback() {
+    unsafe extern "C-unwind" fn polled_events_callback() {
         let Some(api) = event_loop_api() else {
             return;
         };
 
-        run_input_handlers(api);
+        run_activity_handlers(api);
     }
 
-    unsafe extern "C" fn read_console_callback(
+    unsafe extern "C-unwind" fn read_console_callback(
         prompt: *const c_char,
         buffer: *mut c_uchar,
         buflen: c_int,
@@ -592,7 +618,7 @@ mod unix_host {
         ret
     }
 
-    unsafe extern "C" fn read_console_callback_inner(
+    unsafe extern "C-unwind" fn read_console_callback_inner(
         prompt: *const c_char,
         buffer: *mut c_uchar,
         buflen: c_int,
@@ -605,6 +631,7 @@ mod unix_host {
         let prompt_text = c_string_to_string(prompt);
         let wait_kind = classify_wait_kind(&prompt_text, add_history);
         let mut wait_event_emitted = false;
+        set_r_interrupts_pending(false);
         let mut state = runtime.state.lock().expect("host state lock poisoned");
 
         loop {
@@ -647,6 +674,29 @@ mod unix_host {
                 );
             }
 
+            if should_return_startup_input(&wait_kind, &mut state) {
+                return write_read_buffer(
+                    buffer,
+                    buflen,
+                    STARTUP_INTERRUPT_HANDLER_INPUT.as_bytes().to_vec(),
+                    &mut state,
+                    false,
+                    &runtime.output,
+                );
+            }
+
+            if should_return_top_level_recovery(&wait_kind, &mut state) {
+                let recovery_input = take_top_level_recovery_input(&mut state);
+                return write_read_buffer(
+                    buffer,
+                    buflen,
+                    recovery_input,
+                    &mut state,
+                    false,
+                    &runtime.output,
+                );
+            }
+
             if let Some(line) = take_next_line(&wait_kind, &mut state) {
                 return write_read_buffer(
                     buffer,
@@ -668,6 +718,7 @@ mod unix_host {
 
             if state.interrupt_requested && matches!(wait_kind, WaitKind::Nested(_)) {
                 state.interrupt_requested = false;
+                state.top_level_recovery_pending = Some(TopLevelRecovery::RecoverFromInterrupt);
                 let _ = runtime.output.emit_input_end();
                 let _ = runtime.output.emit_output_flush();
                 READ_CONSOLE_INTERRUPTED.store(true, Ordering::Relaxed);
@@ -736,10 +787,16 @@ mod unix_host {
             let mut should_signal = false;
             {
                 let mut state = runtime.state.lock().expect("host state lock poisoned");
+                let was_busy = state.busy;
                 state.busy = value != 0;
                 if value != 0 {
                     should_signal = state.interrupt_requested;
                 } else {
+                    if state.top_level_recovery_active {
+                        state.top_level_recovery_active = false;
+                    } else if was_busy && state.top_level_recovery_pending.is_none() {
+                        state.top_level_recovery_pending = Some(TopLevelRecovery::ParseNull);
+                    }
                     state.suppress_idle_event_pump = state.interrupt_requested;
                     state.interrupt_requested = false;
                     set_r_interrupts_pending(false);
@@ -868,6 +925,54 @@ mod unix_host {
         }
     }
 
+    fn should_return_top_level_recovery(wait_kind: &WaitKind, state: &mut SharedState) -> bool {
+        if !matches!(wait_kind, WaitKind::TopLevel(PromptKind::Main)) {
+            return false;
+        }
+
+        if state.top_level_recovery_active && !state.busy {
+            state.top_level_recovery_active = false;
+        }
+
+        if state.top_level_recovery_pending.is_none() {
+            return false;
+        }
+        if state.pending_fragment.is_some() || !state.active_submission_lines.is_empty() {
+            return false;
+        }
+
+        state.top_level_recovery_active = true;
+        true
+    }
+
+    fn should_return_startup_input(wait_kind: &WaitKind, state: &mut SharedState) -> bool {
+        if !state.startup_input_pending {
+            return false;
+        }
+        if !matches!(wait_kind, WaitKind::TopLevel(PromptKind::Main)) {
+            return false;
+        }
+        if state.pending_fragment.is_some() || !state.active_submission_lines.is_empty() {
+            return false;
+        }
+
+        state.startup_input_pending = false;
+        true
+    }
+
+    fn take_top_level_recovery_input(state: &mut SharedState) -> Vec<u8> {
+        match state
+            .top_level_recovery_pending
+            .take()
+            .unwrap_or(TopLevelRecovery::ParseNull)
+        {
+            TopLevelRecovery::ParseNull => b" ".to_vec(),
+            TopLevelRecovery::RecoverFromInterrupt => {
+                b"base::invisible(base::.Last.value)".to_vec()
+            }
+        }
+    }
+
     fn take_next_parse_request(state: &mut SharedState) -> Option<(u32, String)> {
         let index = state
             .pending_commands
@@ -899,6 +1004,7 @@ mod unix_host {
             target[bytes.len()] = b'\n';
             target[bytes.len() + 1] = 0;
             if signal_input_end {
+                state.top_level_recovery_pending = Some(TopLevelRecovery::ParseNull);
                 let _ = output.emit_input_end();
                 let _ = output.emit_output_flush();
             }
@@ -1159,6 +1265,11 @@ mod unix_host {
                 ),
                 r_interrupts_pending: load_optional_global(&library, b"R_interrupts_pending\0"),
                 r_check_user_interrupt: load_optional_function(&library, b"R_CheckUserInterrupt\0"),
+                r_process_events: load_optional_function(&library, b"R_ProcessEvents\0"),
+                r_run_pending_finalizers: load_optional_function(
+                    &library,
+                    b"R_RunPendingFinalizers\0",
+                ),
                 r_check_activity: load_function(&library, b"R_checkActivity\0")?,
                 r_run_handlers: load_function(&library, b"R_runHandlers\0")?,
                 r_input_handlers: load_global(&library, b"R_InputHandlers\0")?,
@@ -1188,7 +1299,7 @@ mod unix_host {
                 *value = 1;
             }
             if let Some(value) = self.r_signal_handlers {
-                *value = 1;
+                *value = 0;
             }
 
             let mut argv_storage = build_r_args(r_executable, r_args)?;
@@ -1269,6 +1380,8 @@ mod unix_host {
 
         fn event_loop_api(&self) -> EventLoopApi {
             EventLoopApi {
+                r_process_events: self.r_process_events,
+                r_run_pending_finalizers: self.r_run_pending_finalizers,
                 r_check_activity: self.r_check_activity,
                 r_run_handlers: self.r_run_handlers,
                 r_toplevel_exec: self.r_toplevel_exec,
@@ -1330,8 +1443,8 @@ mod unix_host {
 #[cfg(windows)]
 mod windows_host {
     use crate::protocol::{
-        read_next_command, DialogRequest, DialogResult, IncomingCommand, OutputSink,
-        OutputStream, PromptKind,
+        read_next_command, DialogRequest, DialogResult, IncomingCommand, OutputSink, OutputStream,
+        PromptKind,
     };
     use libloading::os::windows::{
         Library as WindowsLibrary, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR, LOAD_LIBRARY_SEARCH_SYSTEM32,
@@ -1347,11 +1460,10 @@ mod windows_host {
     use std::sync::{Condvar, Mutex, OnceLock};
     use std::time::Duration;
     use windows_sys::Win32::{
-        Globalization::{
-            MultiByteToWideChar, WideCharToMultiByte, CP_ACP, WC_NO_BEST_FIT_CHARS,
+        Globalization::{MultiByteToWideChar, WideCharToMultiByte, CP_ACP, WC_NO_BEST_FIT_CHARS},
+        UI::WindowsAndMessaging::{
+            DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE,
         },
-        System::LibraryLoader::{GetModuleHandleA, GetProcAddress},
-        UI::WindowsAndMessaging::{DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE},
     };
 
     const CONT_PROMPT: &str = "+ ";
@@ -1381,7 +1493,8 @@ mod windows_host {
 
     type SetupRMainloop = unsafe extern "C" fn();
     type RunRMainloop = unsafe extern "C" fn();
-    type ReadConsoleFn = unsafe extern "C" fn(*const c_char, *mut c_uchar, c_int, c_int) -> c_int;
+    type ReadConsoleFn =
+        unsafe extern "C-unwind" fn(*const c_char, *mut c_uchar, c_int, c_int) -> c_int;
     type WriteConsoleFn = unsafe extern "C" fn(*const c_char, c_int);
     type WriteConsoleExFn = unsafe extern "C" fn(*const c_char, c_int, c_int);
     type ShowMessageFn = unsafe extern "C" fn(*const c_char);
@@ -1395,11 +1508,12 @@ mod windows_host {
         *const *const c_char,
         *const c_char,
     ) -> c_int;
-    type EventCallbackFn = unsafe extern "C" fn();
+    type EventCallbackFn = unsafe extern "C-unwind" fn();
     type YesNoCancelFn = unsafe extern "C" fn(*const c_char) -> c_int;
     type ExpandFileNameFn = unsafe extern "C" fn(*const c_char) -> *const c_char;
     type CheckUserInterruptFn = unsafe extern "C" fn();
     type ProcessEventsFn = unsafe extern "C" fn();
+    type RunPendingFinalizersFn = unsafe extern "C" fn();
     type CheckActivityFn = unsafe extern "C" fn(c_int, c_int) -> *mut c_void;
     type RunHandlersFn = unsafe extern "C" fn(*mut c_void, *mut c_void);
     type Sexp = *mut c_void;
@@ -1407,11 +1521,8 @@ mod windows_host {
     type InstallFn = unsafe extern "C" fn(*const c_char) -> Sexp;
     type FindVarInFrameFn = unsafe extern "C" fn(Sexp, Sexp) -> Sexp;
     type ScalarIntegerFn = unsafe extern "C" fn(c_int) -> Sexp;
-    type ScalarLogicalFn = unsafe extern "C" fn(c_int) -> Sexp;
-    type ScalarRealFn = unsafe extern "C" fn(f64) -> Sexp;
     type ProtectFn = unsafe extern "C" fn(Sexp) -> Sexp;
     type UnprotectFn = unsafe extern "C" fn(c_int);
-    type LaterExecCallbacksFn = unsafe extern "C" fn(Sexp, Sexp, Sexp) -> Sexp;
     type ParseVectorFn = unsafe extern "C" fn(Sexp, c_int, *mut c_int, Sexp) -> Sexp;
     type TopLevelExecFn =
         unsafe extern "C" fn(unsafe extern "C" fn(*mut c_void), *mut c_void) -> c_int;
@@ -1510,6 +1621,7 @@ mod windows_host {
         ga_initapp: Option<GAInitAppFn>,
         ga_peekevent: Option<GAPeekEventFn>,
         r_process_events: Option<ProcessEventsFn>,
+        r_run_pending_finalizers: Option<RunPendingFinalizersFn>,
         ptr_r_process_events: Option<*mut Option<EventCallbackFn>>,
         r_polled_events: Option<*mut Option<EventCallbackFn>>,
         r_check_activity: Option<CheckActivityFn>,
@@ -1530,8 +1642,6 @@ mod windows_host {
         rf_install: InstallFn,
         rf_find_var_in_frame: FindVarInFrameFn,
         rf_scalar_integer: ScalarIntegerFn,
-        rf_scalar_logical: ScalarLogicalFn,
-        rf_scalar_real: ScalarRealFn,
         rf_protect: ProtectFn,
         rf_unprotect: UnprotectFn,
         r_parse_vector: ParseVectorFn,
@@ -1562,10 +1672,19 @@ mod windows_host {
         pending_dialog_result: Option<DialogResult>,
         pending_width: Option<u16>,
         current_width: Option<u16>,
+        startup_input_pending: bool,
         busy: bool,
         interrupt_requested: bool,
         suppress_idle_event_pump: bool,
+        top_level_recovery_pending: Option<TopLevelRecovery>,
+        top_level_recovery_active: bool,
         shutdown_requested: bool,
+    }
+
+    #[derive(Clone, Copy)]
+    enum TopLevelRecovery {
+        ParseNull,
+        RecoverFromInterrupt,
     }
 
     enum PendingCommand {
@@ -1618,11 +1737,8 @@ mod windows_host {
         r_check_activity: Option<CheckActivityFn>,
         r_run_handlers: Option<RunHandlersFn>,
         r_input_handlers: Option<usize>,
-        rf_scalar_integer: ScalarIntegerFn,
-        rf_scalar_logical: ScalarLogicalFn,
-        rf_scalar_real: ScalarRealFn,
-        rf_protect: ProtectFn,
-        rf_unprotect: UnprotectFn,
+        r_run_pending_finalizers: Option<RunPendingFinalizersFn>,
+        r_toplevel_exec: TopLevelExecFn,
     }
 
     struct ParseStatusContext {
@@ -1636,6 +1752,12 @@ mod windows_host {
         width: c_int,
         success: bool,
     }
+
+    struct PumpEventsContext {
+        api: EventLoopApi,
+    }
+
+    const STARTUP_INTERRUPT_HANDLER_INPUT: &str = r#"base::local({ if (base::getRversion() >= "4.0.0") { handler <- function(e) { restart <- base::findRestart("abort"); if (!base::is.null(restart)) base::invokeRestart(restart) }; handlers <- base::globalCallingHandlers(); base::globalCallingHandlers(NULL); handlers <- c(handlers, list(interrupt = handler)); base::do.call(base::globalCallingHandlers, handlers) }; base::invisible(NULL) }, envir = base::new.env(parent = base::baseenv()))"#;
 
     pub(crate) fn run(args: Vec<String>) -> Result<(), Box<dyn Error>> {
         if args.is_empty() {
@@ -1653,7 +1775,10 @@ mod windows_host {
         HOST_RUNTIME
             .set(HostRuntime {
                 output: output.clone_handle(),
-                state: Mutex::new(SharedState::default()),
+                state: Mutex::new(SharedState {
+                    startup_input_pending: true,
+                    ..SharedState::default()
+                }),
                 cv: Condvar::new(),
             })
             .map_err(|_| "host runtime already initialized")?;
@@ -1801,6 +1926,7 @@ mod windows_host {
         if let Some(runtime) = host_runtime() {
             let mut state = runtime.state.lock().expect("host state lock poisoned");
             state.interrupt_requested = true;
+            state.top_level_recovery_pending = Some(TopLevelRecovery::RecoverFromInterrupt);
             runtime.cv.notify_all();
         }
 
@@ -1954,12 +2080,25 @@ mod windows_host {
             return;
         };
 
+        let mut context = PumpEventsContext { api };
         unsafe {
-            run_process_events(api);
+            (api.r_toplevel_exec)(
+                execute_pump_events,
+                &mut context as *mut PumpEventsContext as *mut c_void,
+            );
         }
     }
 
-    unsafe fn run_input_handlers(api: EventLoopApi) {
+    unsafe extern "C" fn execute_pump_events(data: *mut c_void) {
+        if data.is_null() {
+            return;
+        }
+
+        let context = &mut *(data as *mut PumpEventsContext);
+        run_process_events(context.api);
+    }
+
+    unsafe fn run_activity_handlers(api: EventLoopApi) {
         let Some(check_activity) = api.r_check_activity else {
             return;
         };
@@ -1975,8 +2114,11 @@ mod windows_host {
             return;
         }
 
-        let mask = check_activity(0, 1);
-        run_handlers(handlers, mask);
+        let mut mask = check_activity(0, 1);
+        while !mask.is_null() {
+            run_handlers(handlers, mask);
+            mask = check_activity(0, 1);
+        }
     }
 
     unsafe fn run_process_events(api: EventLoopApi) {
@@ -1984,30 +2126,13 @@ mod windows_host {
         // handled by R's native callback path below, but calling it here can
         // stall the wait loop before the session webserver is serviced.
         pump_windows_messages();
-        run_input_handlers(api);
-        run_later_exec_callbacks(api);
         if let Some(process_events) = api.r_process_events {
             process_events();
         }
-    }
-
-    unsafe fn run_later_exec_callbacks(api: EventLoopApi) {
-        let module = GetModuleHandleA(c"later.dll".as_ptr() as *const u8);
-        if module.is_null() {
-            return;
+        run_activity_handlers(api);
+        if let Some(run_pending_finalizers) = api.r_run_pending_finalizers {
+            run_pending_finalizers();
         }
-
-        let Some(address) = GetProcAddress(module, c"_later_execCallbacks".as_ptr() as *const u8)
-        else {
-            return;
-        };
-
-        let exec_callbacks: LaterExecCallbacksFn = std::mem::transmute(address);
-        let timeout = (api.rf_protect)((api.rf_scalar_real)(0.0));
-        let run_all = (api.rf_protect)((api.rf_scalar_logical)(0));
-        let loop_id = (api.rf_protect)((api.rf_scalar_integer)(0));
-        let _ = exec_callbacks(timeout, run_all, loop_id);
-        (api.rf_unprotect)(3);
     }
 
     unsafe fn pump_windows_messages() {
@@ -2018,20 +2143,17 @@ mod windows_host {
         }
     }
 
-    unsafe extern "C" fn process_events_callback() {
+    unsafe extern "C-unwind" fn process_events_callback() {
         if let Some(api) = event_loop_api() {
             if !PROCESS_EVENTS_CALLBACK_ACTIVE.swap(true, Ordering::AcqRel) {
                 if let Some(peek_event) = api.ga_peekevent {
                     while peek_event() != 0 {}
                 }
                 pump_windows_messages();
-                // Drive the input-handler path that httpuv and other socket-based
-                // integrations rely on, matching the Unix embedded host wiring.
-                run_input_handlers(api);
+                run_activity_handlers(api);
                 PROCESS_EVENTS_CALLBACK_ACTIVE.store(false, Ordering::Release);
             }
         }
-
         if let Some(runtime) = host_runtime() {
             let state = runtime.state.lock().expect("host state lock poisoned");
             if state.interrupt_requested {
@@ -2040,17 +2162,17 @@ mod windows_host {
         }
     }
 
-    unsafe extern "C" fn polled_events_callback() {
+    unsafe extern "C-unwind" fn polled_events_callback() {
         if let Some(api) = event_loop_api() {
             if !PROCESS_EVENTS_CALLBACK_ACTIVE.swap(true, Ordering::AcqRel) {
                 pump_windows_messages();
-                run_input_handlers(api);
+                run_activity_handlers(api);
                 PROCESS_EVENTS_CALLBACK_ACTIVE.store(false, Ordering::Release);
             }
         }
     }
 
-    unsafe extern "C" fn read_console_callback(
+    unsafe extern "C-unwind" fn read_console_callback(
         prompt: *const c_char,
         buffer: *mut c_uchar,
         buflen: c_int,
@@ -2068,7 +2190,7 @@ mod windows_host {
         ret
     }
 
-    unsafe extern "C" fn read_console_callback_inner(
+    unsafe extern "C-unwind" fn read_console_callback_inner(
         prompt: *const c_char,
         buffer: *mut c_uchar,
         buflen: c_int,
@@ -2081,6 +2203,7 @@ mod windows_host {
         let prompt_text = c_string_to_string(prompt);
         let wait_kind = classify_wait_kind(&prompt_text, add_history);
         let mut wait_event_emitted = false;
+        set_r_interrupts_pending(false);
         let mut state = runtime.state.lock().expect("host state lock poisoned");
 
         loop {
@@ -2123,6 +2246,29 @@ mod windows_host {
                 );
             }
 
+            if should_return_startup_input(&wait_kind, &mut state) {
+                return write_read_buffer(
+                    buffer,
+                    buflen,
+                    encode_windows_r_source_text(STARTUP_INTERRUPT_HANDLER_INPUT),
+                    &mut state,
+                    false,
+                    &runtime.output,
+                );
+            }
+
+            if should_return_top_level_recovery(&wait_kind, &mut state) {
+                let recovery_input = take_top_level_recovery_input(&mut state);
+                return write_read_buffer(
+                    buffer,
+                    buflen,
+                    recovery_input,
+                    &mut state,
+                    false,
+                    &runtime.output,
+                );
+            }
+
             if let Some(line) = take_next_line(&wait_kind, &mut state) {
                 return write_read_buffer(
                     buffer,
@@ -2144,6 +2290,7 @@ mod windows_host {
 
             if state.interrupt_requested && matches!(wait_kind, WaitKind::Nested(_)) {
                 state.interrupt_requested = false;
+                state.top_level_recovery_pending = Some(TopLevelRecovery::RecoverFromInterrupt);
                 let _ = runtime.output.emit_input_end();
                 let _ = runtime.output.emit_output_flush();
                 READ_CONSOLE_INTERRUPTED.store(true, Ordering::Relaxed);
@@ -2222,8 +2369,14 @@ mod windows_host {
             let should_preserve_interrupt;
             {
                 let mut state = runtime.state.lock().expect("host state lock poisoned");
+                let was_busy = state.busy;
                 state.busy = value != 0;
                 if value == 0 {
+                    if state.top_level_recovery_active {
+                        state.top_level_recovery_active = false;
+                    } else if was_busy && state.top_level_recovery_pending.is_none() {
+                        state.top_level_recovery_pending = Some(TopLevelRecovery::ParseNull);
+                    }
                     state.suppress_idle_event_pump = state.interrupt_requested;
                     state.interrupt_requested = false;
                     set_r_interrupts_pending(false);
@@ -2353,6 +2506,54 @@ mod windows_host {
         }
     }
 
+    fn should_return_top_level_recovery(wait_kind: &WaitKind, state: &mut SharedState) -> bool {
+        if !matches!(wait_kind, WaitKind::TopLevel(PromptKind::Main)) {
+            return false;
+        }
+
+        if state.top_level_recovery_active && !state.busy {
+            state.top_level_recovery_active = false;
+        }
+
+        if state.top_level_recovery_pending.is_none() {
+            return false;
+        }
+        if state.pending_fragment.is_some() || !state.active_submission_lines.is_empty() {
+            return false;
+        }
+
+        state.top_level_recovery_active = true;
+        true
+    }
+
+    fn should_return_startup_input(wait_kind: &WaitKind, state: &mut SharedState) -> bool {
+        if !state.startup_input_pending {
+            return false;
+        }
+        if !matches!(wait_kind, WaitKind::TopLevel(PromptKind::Main)) {
+            return false;
+        }
+        if state.pending_fragment.is_some() || !state.active_submission_lines.is_empty() {
+            return false;
+        }
+
+        state.startup_input_pending = false;
+        true
+    }
+
+    fn take_top_level_recovery_input(state: &mut SharedState) -> Vec<u8> {
+        match state
+            .top_level_recovery_pending
+            .take()
+            .unwrap_or(TopLevelRecovery::ParseNull)
+        {
+            TopLevelRecovery::ParseNull => b" ".to_vec(),
+            TopLevelRecovery::RecoverFromInterrupt => {
+                b"base::invisible(base::.Last.value)".to_vec()
+            }
+        }
+    }
+
     fn take_next_parse_request(state: &mut SharedState) -> Option<(u32, String)> {
         let index = state
             .pending_commands
@@ -2384,6 +2585,7 @@ mod windows_host {
             target[bytes.len()] = b'\n';
             target[bytes.len() + 1] = 0;
             if signal_input_end {
+                state.top_level_recovery_pending = Some(TopLevelRecovery::ParseNull);
                 let _ = output.emit_input_end();
                 let _ = output.emit_output_flush();
             }
@@ -3030,6 +3232,10 @@ mod windows_host {
                 ga_initapp,
                 ga_peekevent,
                 r_process_events: load_optional_function(&library, b"R_ProcessEvents\0"),
+                r_run_pending_finalizers: load_optional_function(
+                    &library,
+                    b"R_RunPendingFinalizers\0",
+                ),
                 ptr_r_process_events: load_optional_global(&library, b"ptr_R_ProcessEvents\0"),
                 r_polled_events: load_optional_global(&library, b"R_PolledEvents\0"),
                 r_check_activity: load_optional_function(&library, b"R_checkActivity\0"),
@@ -3054,8 +3260,6 @@ mod windows_host {
                 rf_install: load_function(&library, b"Rf_install\0")?,
                 rf_find_var_in_frame: load_function(&library, b"Rf_findVarInFrame\0")?,
                 rf_scalar_integer: load_function(&library, b"Rf_ScalarInteger\0")?,
-                rf_scalar_logical: load_function(&library, b"Rf_ScalarLogical\0")?,
-                rf_scalar_real: load_function(&library, b"Rf_ScalarReal\0")?,
                 rf_protect: load_function(&library, b"Rf_protect\0")?,
                 rf_unprotect: load_function(&library, b"Rf_unprotect\0")?,
                 r_parse_vector: load_function(&library, b"R_ParseVector\0")?,
@@ -3220,11 +3424,8 @@ mod windows_host {
                 r_check_activity: self.r_check_activity,
                 r_run_handlers: self.r_run_handlers,
                 r_input_handlers: self.r_input_handlers.map(|value| value as usize),
-                rf_scalar_integer: self.rf_scalar_integer,
-                rf_scalar_logical: self.rf_scalar_logical,
-                rf_scalar_real: self.rf_scalar_real,
-                rf_protect: self.rf_protect,
-                rf_unprotect: self.rf_unprotect,
+                r_run_pending_finalizers: self.r_run_pending_finalizers,
+                r_toplevel_exec: self.r_toplevel_exec,
             }
         }
     }
@@ -3288,8 +3489,11 @@ mod windows_host {
     #[cfg(test)]
     mod tests {
         use super::{
-            decode_windows_console_text_with_code_page, encode_windows_r_source_text_with_code_page,
+            decode_windows_console_text_with_code_page,
+            encode_windows_r_source_text_with_code_page, should_return_top_level_recovery,
+            take_top_level_recovery_input, SharedState, TopLevelRecovery, WaitKind,
         };
+        use crate::protocol::PromptKind;
 
         #[test]
         fn decodes_embedded_utf8_console_segments() {
@@ -3402,6 +3606,73 @@ mod windows_host {
                     1252,
                 ),
                 b"\\u65e5\\u672c\\u8a9e \\U0001f642"
+            );
+        }
+
+        #[test]
+        fn top_level_recovery_runs_once_at_main_prompt() {
+            let mut state = SharedState {
+                top_level_recovery_pending: Some(TopLevelRecovery::ParseNull),
+                ..SharedState::default()
+            };
+            let prompt = WaitKind::TopLevel(PromptKind::Main);
+
+            assert!(should_return_top_level_recovery(&prompt, &mut state));
+            assert_eq!(take_top_level_recovery_input(&mut state), b" ".to_vec());
+            assert!(state.top_level_recovery_pending.is_none());
+            assert!(state.top_level_recovery_active);
+
+            assert!(!should_return_top_level_recovery(&prompt, &mut state));
+            assert!(!state.top_level_recovery_active);
+        }
+
+        #[test]
+        fn top_level_recovery_waits_for_main_prompt_without_active_input() {
+            let mut state = SharedState {
+                top_level_recovery_pending: Some(TopLevelRecovery::ParseNull),
+                ..SharedState::default()
+            };
+
+            assert!(!should_return_top_level_recovery(
+                &WaitKind::TopLevel(PromptKind::Cont),
+                &mut state
+            ));
+            assert!(state.top_level_recovery_pending.is_some());
+
+            assert!(!should_return_top_level_recovery(
+                &WaitKind::Nested("readline> ".to_string()),
+                &mut state
+            ));
+            assert!(state.top_level_recovery_pending.is_some());
+
+            state.active_submission_lines.push_back(b"next".to_vec());
+            assert!(!should_return_top_level_recovery(
+                &WaitKind::TopLevel(PromptKind::Main),
+                &mut state
+            ));
+            assert!(state.top_level_recovery_pending.is_some());
+
+            state.active_submission_lines.clear();
+            assert!(should_return_top_level_recovery(
+                &WaitKind::TopLevel(PromptKind::Main),
+                &mut state
+            ));
+        }
+
+        #[test]
+        fn top_level_recovery_uses_last_value_for_interrupted_evaluation() {
+            let mut state = SharedState {
+                top_level_recovery_pending: Some(TopLevelRecovery::RecoverFromInterrupt),
+                ..SharedState::default()
+            };
+
+            assert!(should_return_top_level_recovery(
+                &WaitKind::TopLevel(PromptKind::Main),
+                &mut state
+            ));
+            assert_eq!(
+                take_top_level_recovery_input(&mut state),
+                b"base::invisible(base::.Last.value)".to_vec()
             );
         }
 

--- a/sidecar/pty-host/src/host.rs
+++ b/sidecar/pty-host/src/host.rs
@@ -10,20 +10,24 @@ pub(crate) fn run(_args: Vec<String>) -> Result<(), Box<dyn Error>> {
 mod unix_host {
     use crate::protocol::{
         read_next_command, DialogRequest, DialogResult, IncomingCommand, OutputSink, OutputStream,
-        PromptKind,
+        PromptKind, SessionWaitState,
     };
     use libloading::os::unix::{Library, Symbol};
     use std::collections::VecDeque;
     use std::error::Error;
     use std::ffi::{c_char, c_int, c_uchar, c_void, CStr, CString};
+    use std::fs;
     use std::io;
+    use std::net::TcpListener;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::{Condvar, Mutex, OnceLock};
-    use std::time::Duration;
+    use std::sync::{mpsc, Arc, Condvar, Mutex, OnceLock};
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     const CONT_PROMPT: &str = "+ ";
     const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+    const SESSION_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
     const SUPPORTED_CAPABILITIES: &[&str] = &[
         "control-channel",
@@ -150,12 +154,19 @@ mod unix_host {
         top_level_recovery_pending: Option<TopLevelRecovery>,
         top_level_recovery_active: bool,
         shutdown_requested: bool,
+        wait_state: Option<StoredWaitState>,
     }
 
     #[derive(Clone, Copy)]
     enum TopLevelRecovery {
         ParseNull,
         RecoverFromInterrupt,
+    }
+
+    #[derive(Clone)]
+    enum StoredWaitState {
+        TopLevel(PromptKind),
+        Nested(String),
     }
 
     enum PendingCommand {
@@ -238,7 +249,14 @@ mod unix_host {
         let api = unsafe { RApi::load(&library_path)? };
 
         let output = OutputSink::new_with_capabilities("embedded-r-host", SUPPORTED_CAPABILITIES);
-        output.emit_backend_ready()?;
+        let session_transport = session_transport_config().is_some();
+        if let Err(error) = output.capture_process_stdout() {
+            let _ =
+                output.emit_host_error(&format!("backend stdout capture setup failed: {error}"));
+        }
+        if !session_transport {
+            output.emit_backend_ready()?;
+        }
 
         HOST_RUNTIME
             .set(HostRuntime {
@@ -273,8 +291,10 @@ mod unix_host {
             }
         }
 
-        output.emit_child_spawned(std::process::id())?;
-        output.emit_host_connected()?;
+        if !session_transport {
+            output.emit_host_connected()?;
+            output.emit_session_state(std::process::id(), false, SessionWaitState::None)?;
+        }
 
         unsafe {
             (api.run_rmainloop)();
@@ -284,7 +304,14 @@ mod unix_host {
     }
 
     fn start_command_reader() {
-        std::thread::spawn(move || {
+        if let Some((session_file, initial_connect_grace, reconnect_grace)) =
+            session_transport_config()
+        {
+            start_session_command_reader(session_file, initial_connect_grace, reconnect_grace);
+            return;
+        }
+
+        thread::spawn(move || {
             let stdin = io::stdin();
             let mut locked = stdin.lock();
             loop {
@@ -302,6 +329,230 @@ mod unix_host {
                 }
             }
         });
+    }
+
+    fn start_session_command_reader(
+        session_file: String,
+        initial_connect_grace: Duration,
+        reconnect_grace: Option<Duration>,
+    ) {
+        thread::spawn(move || {
+            let listener = match TcpListener::bind(("127.0.0.1", 0)) {
+                Ok(listener) => listener,
+                Err(error) => {
+                    emit_host_error(&format!("backend session server bind failed: {error}"));
+                    request_shutdown();
+                    return;
+                }
+            };
+            if let Err(error) = listener.set_nonblocking(true) {
+                emit_host_error(&format!("backend session server setup failed: {error}"));
+                request_shutdown();
+                return;
+            }
+
+            let port = match listener.local_addr() {
+                Ok(addr) => addr.port(),
+                Err(error) => {
+                    emit_host_error(&format!("backend session server address failed: {error}"));
+                    request_shutdown();
+                    return;
+                }
+            };
+            if let Err(error) = write_session_bootstrap(&session_file, port, std::process::id()) {
+                emit_host_error(&format!("backend session bootstrap write failed: {error}"));
+                request_shutdown();
+                return;
+            }
+
+            let (disconnect_tx, disconnect_rx) = mpsc::channel::<usize>();
+            let current_client = Arc::new(AtomicUsize::new(0));
+            let client_connected = Arc::new(AtomicBool::new(false));
+            let mut next_client_id = 0_usize;
+            let mut disconnect_deadline = Some(Instant::now() + initial_connect_grace);
+
+            loop {
+                let mut should_break = false;
+                while let Ok(client_id) = disconnect_rx.try_recv() {
+                    if current_client.load(Ordering::SeqCst) != client_id {
+                        continue;
+                    }
+                    if let Some(runtime) = host_runtime() {
+                        runtime.output.detach_client();
+                    }
+                    client_connected.store(false, Ordering::SeqCst);
+                    if is_shutdown_requested() {
+                        should_break = true;
+                        break;
+                    }
+                    disconnect_deadline = reconnect_grace.map(|grace| Instant::now() + grace);
+                }
+                if should_break {
+                    break;
+                }
+
+                match listener.accept() {
+                    Ok((mut stream, _addr)) => {
+                        if let Err(error) = stream.set_nonblocking(false) {
+                            emit_host_error(&format!(
+                                "backend session stream setup failed: {error}"
+                            ));
+                            request_shutdown();
+                            break;
+                        }
+                        let writer = match stream.try_clone() {
+                            Ok(writer) => writer,
+                            Err(error) => {
+                                emit_host_error(&format!(
+                                    "backend session stream clone failed: {error}"
+                                ));
+                                request_shutdown();
+                                break;
+                            }
+                        };
+                        next_client_id = next_client_id.wrapping_add(1).max(1);
+                        let client_id = next_client_id;
+                        current_client.store(client_id, Ordering::SeqCst);
+                        client_connected.store(true, Ordering::SeqCst);
+                        disconnect_deadline = None;
+                        if let Err(error) = writer.set_nonblocking(false) {
+                            emit_host_error(&format!(
+                                "backend session writer setup failed: {error}"
+                            ));
+                            request_shutdown();
+                            break;
+                        }
+                        if let Some(runtime) = host_runtime() {
+                            runtime.output.attach_client(writer);
+                            emit_attached_client_state(runtime);
+                        }
+
+                        let reader_current_client = Arc::clone(&current_client);
+                        let reader_disconnect_tx = disconnect_tx.clone();
+                        thread::spawn(move || {
+                            loop {
+                                match read_next_command(&mut stream) {
+                                    Ok(Some(command)) => {
+                                        if reader_current_client.load(Ordering::SeqCst) != client_id
+                                        {
+                                            break;
+                                        }
+                                        handle_command(command);
+                                        if is_shutdown_requested() {
+                                            break;
+                                        }
+                                    }
+                                    Ok(None) => break,
+                                    Err(error) => {
+                                        if reader_current_client.load(Ordering::SeqCst) == client_id
+                                            && !is_expected_session_disconnect_error(&error)
+                                        {
+                                            emit_host_error(&format!(
+                                                "backend command read failed: {error}"
+                                            ));
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                            let _ = reader_disconnect_tx.send(client_id);
+                        });
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        if is_shutdown_requested() {
+                            break;
+                        }
+                        if !client_connected.load(Ordering::SeqCst) {
+                            if let Some(deadline) = disconnect_deadline {
+                                if Instant::now() >= deadline {
+                                    request_shutdown();
+                                    break;
+                                }
+                            }
+                        }
+                        thread::sleep(SESSION_ACCEPT_POLL_INTERVAL);
+                    }
+                    Err(error) => {
+                        emit_host_error(&format!("backend session accept failed: {error}"));
+                        request_shutdown();
+                        break;
+                    }
+                }
+            }
+            let _ = fs::remove_file(&session_file);
+        });
+    }
+
+    fn session_transport_config() -> Option<(String, Duration, Option<Duration>)> {
+        let session_file = std::env::var("VSC_R_BACKEND_SESSION_FILE").ok()?;
+        if session_file.trim().is_empty() {
+            return None;
+        }
+        let initial_connect_grace_ms = std::env::var("VSC_R_BACKEND_INITIAL_CONNECT_GRACE_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(60_000);
+        let reconnect_grace = std::env::var("VSC_R_BACKEND_RECONNECT_GRACE_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .and_then(|value| {
+                if value == 0 {
+                    None
+                } else {
+                    Some(Duration::from_millis(value))
+                }
+            });
+        Some((
+            session_file,
+            Duration::from_millis(initial_connect_grace_ms),
+            reconnect_grace,
+        ))
+    }
+
+    fn write_session_bootstrap(session_file: &str, port: u16, pid: u32) -> io::Result<()> {
+        let payload = format!("{{\"port\":{port},\"pid\":{pid}}}");
+        fs::write(session_file, payload)
+    }
+
+    fn emit_attached_client_state(runtime: &HostRuntime) {
+        let pid = std::process::id();
+        let _ = runtime.output.flush_backlog();
+        let _ = runtime.output.emit_backend_ready();
+        let _ = runtime.output.emit_host_connected();
+
+        let (busy, wait_state) = {
+            let state = runtime.state.lock().expect("host state lock poisoned");
+            (state.busy, state.wait_state.clone())
+        };
+        let wait = match wait_state {
+            Some(StoredWaitState::TopLevel(kind)) => SessionWaitState::TopLevel(kind),
+            Some(StoredWaitState::Nested(prompt)) => SessionWaitState::Nested(prompt),
+            None => SessionWaitState::None,
+        };
+        let _ = runtime.output.emit_session_state(pid, busy, wait);
+        let _ = runtime.output.emit_output_flush();
+    }
+
+    fn is_expected_session_disconnect_error(error: &io::Error) -> bool {
+        matches!(
+            error.kind(),
+            io::ErrorKind::ConnectionReset
+                | io::ErrorKind::ConnectionAborted
+                | io::ErrorKind::BrokenPipe
+                | io::ErrorKind::UnexpectedEof
+        )
+    }
+
+    fn is_shutdown_requested() -> bool {
+        host_runtime()
+            .map(|runtime| {
+                runtime
+                    .state
+                    .lock()
+                    .expect("host state lock poisoned")
+                    .shutdown_requested
+            })
+            .unwrap_or(false)
     }
 
     fn handle_command(command: IncomingCommand) {
@@ -664,6 +915,7 @@ mod unix_host {
             if let Some(fragment) = state.pending_fragment.take() {
                 let signal_input_end = state.pending_fragment_from_nested;
                 state.pending_fragment_from_nested = false;
+                state.wait_state = None;
                 return write_read_buffer(
                     buffer,
                     buflen,
@@ -709,6 +961,7 @@ mod unix_host {
             }
 
             if state.shutdown_requested {
+                state.wait_state = None;
                 if matches!(wait_kind, WaitKind::Nested(_)) {
                     let _ = runtime.output.emit_input_end();
                     let _ = runtime.output.emit_output_flush();
@@ -719,6 +972,7 @@ mod unix_host {
             if state.interrupt_requested && matches!(wait_kind, WaitKind::Nested(_)) {
                 state.interrupt_requested = false;
                 state.top_level_recovery_pending = Some(TopLevelRecovery::RecoverFromInterrupt);
+                state.wait_state = None;
                 let _ = runtime.output.emit_input_end();
                 let _ = runtime.output.emit_output_flush();
                 READ_CONSOLE_INTERRUPTED.store(true, Ordering::Relaxed);
@@ -728,10 +982,12 @@ mod unix_host {
             if !wait_event_emitted {
                 match &wait_kind {
                     WaitKind::TopLevel(kind) => {
+                        state.wait_state = Some(StoredWaitState::TopLevel(*kind));
                         let _ = runtime.output.emit_prompt(*kind);
                         let _ = runtime.output.emit_output_flush();
                     }
                     WaitKind::Nested(prompt) => {
+                        state.wait_state = Some(StoredWaitState::Nested(prompt.clone()));
                         let _ = runtime.output.emit_input_request(prompt);
                         let _ = runtime.output.emit_output_flush();
                     }
@@ -790,6 +1046,7 @@ mod unix_host {
                 let was_busy = state.busy;
                 state.busy = value != 0;
                 if value != 0 {
+                    state.wait_state = None;
                     should_signal = state.interrupt_requested;
                 } else {
                     if state.top_level_recovery_active {
@@ -883,6 +1140,7 @@ mod unix_host {
 
     fn take_next_line(wait_kind: &WaitKind, state: &mut SharedState) -> Option<PendingLine> {
         if let Some(line) = state.active_submission_lines.pop_front() {
+            state.wait_state = None;
             return Some(PendingLine {
                 bytes: line,
                 signal_input_end: false,
@@ -898,6 +1156,7 @@ mod unix_host {
                 match state.pending_commands.remove(index) {
                     Some(PendingCommand::Submit(lines)) => {
                         state.active_submission_lines = lines;
+                        state.wait_state = None;
                         state
                             .active_submission_lines
                             .pop_front()
@@ -915,10 +1174,13 @@ mod unix_host {
                     .iter()
                     .position(|command| matches!(command, PendingCommand::Reply(_)))?;
                 match state.pending_commands.remove(index) {
-                    Some(PendingCommand::Reply(bytes)) => Some(PendingLine {
-                        bytes,
-                        signal_input_end: true,
-                    }),
+                    Some(PendingCommand::Reply(bytes)) => {
+                        state.wait_state = None;
+                        Some(PendingLine {
+                            bytes,
+                            signal_input_end: true,
+                        })
+                    }
                     _ => None,
                 }
             }
@@ -1444,7 +1706,7 @@ mod unix_host {
 mod windows_host {
     use crate::protocol::{
         read_next_command, DialogRequest, DialogResult, IncomingCommand, OutputSink, OutputStream,
-        PromptKind,
+        PromptKind, SessionWaitState,
     };
     use libloading::os::windows::{
         Library as WindowsLibrary, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR, LOAD_LIBRARY_SEARCH_SYSTEM32,
@@ -1453,12 +1715,14 @@ mod windows_host {
     use std::collections::VecDeque;
     use std::error::Error;
     use std::ffi::{c_char, c_int, c_uchar, c_void, CStr, CString};
-    use std::fs::OpenOptions;
+    use std::fs;
     use std::io;
+    use std::net::TcpListener;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::{Condvar, Mutex, OnceLock};
-    use std::time::Duration;
+    use std::sync::{mpsc, Arc, Condvar, Mutex, OnceLock};
+    use std::thread;
+    use std::time::{Duration, Instant};
     use windows_sys::Win32::{
         Globalization::{MultiByteToWideChar, WideCharToMultiByte, CP_ACP, WC_NO_BEST_FIT_CHARS},
         UI::WindowsAndMessaging::{
@@ -1468,6 +1732,7 @@ mod windows_host {
 
     const CONT_PROMPT: &str = "+ ";
     const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+    const SESSION_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
     const EMBEDDED_UTF8_PREFIX: &[u8] = &[0x02, 0xff, 0xfe];
     const EMBEDDED_UTF8_SUFFIX: &[u8] = &[0x03, 0xff, 0xfe];
 
@@ -1679,12 +1944,19 @@ mod windows_host {
         top_level_recovery_pending: Option<TopLevelRecovery>,
         top_level_recovery_active: bool,
         shutdown_requested: bool,
+        wait_state: Option<StoredWaitState>,
     }
 
     #[derive(Clone, Copy)]
     enum TopLevelRecovery {
         ParseNull,
         RecoverFromInterrupt,
+    }
+
+    #[derive(Clone)]
+    enum StoredWaitState {
+        TopLevel(PromptKind),
+        Nested(String),
     }
 
     enum PendingCommand {
@@ -1770,7 +2042,14 @@ mod windows_host {
         let mut api = unsafe { RApi::load(&layout)? };
 
         let output = OutputSink::new_with_capabilities("embedded-r-host", SUPPORTED_CAPABILITIES);
-        output.emit_backend_ready()?;
+        let session_transport = session_transport_config().is_some();
+        if let Err(error) = output.capture_process_stdout() {
+            let _ =
+                output.emit_host_error(&format!("backend stdout capture setup failed: {error}"));
+        }
+        if !session_transport {
+            output.emit_backend_ready()?;
+        }
 
         HOST_RUNTIME
             .set(HostRuntime {
@@ -1805,8 +2084,10 @@ mod windows_host {
             }
         }
 
-        output.emit_child_spawned(std::process::id())?;
-        output.emit_host_connected()?;
+        if !session_transport {
+            output.emit_host_connected()?;
+            output.emit_session_state(std::process::id(), false, SessionWaitState::None)?;
+        }
 
         unsafe {
             (api.run_rmainloop)();
@@ -1816,17 +2097,18 @@ mod windows_host {
     }
 
     fn start_command_reader() {
-        std::thread::spawn(move || {
-            let mut reader = match open_command_reader() {
-                Ok(reader) => reader,
-                Err(error) => {
-                    emit_host_error(&format!("backend command channel open failed: {error}"));
-                    request_shutdown();
-                    return;
-                }
-            };
+        if let Some((session_file, initial_connect_grace, reconnect_grace)) =
+            session_transport_config()
+        {
+            start_session_command_reader(session_file, initial_connect_grace, reconnect_grace);
+            return;
+        }
+
+        thread::spawn(move || {
+            let stdin = io::stdin();
+            let mut locked = stdin.lock();
             loop {
-                match read_next_command(&mut reader) {
+                match read_next_command(&mut locked) {
                     Ok(Some(command)) => handle_command(command),
                     Ok(None) => {
                         request_shutdown();
@@ -1842,14 +2124,228 @@ mod windows_host {
         });
     }
 
-    fn open_command_reader() -> io::Result<Box<dyn io::Read + Send>> {
-        match std::env::var("VSC_R_BACKEND_COMMAND_PIPE") {
-            Ok(path) if !path.trim().is_empty() => {
-                let file = OpenOptions::new().read(true).write(true).open(path)?;
-                Ok(Box::new(file))
+    fn start_session_command_reader(
+        session_file: String,
+        initial_connect_grace: Duration,
+        reconnect_grace: Option<Duration>,
+    ) {
+        thread::spawn(move || {
+            let listener = match TcpListener::bind(("127.0.0.1", 0)) {
+                Ok(listener) => listener,
+                Err(error) => {
+                    emit_host_error(&format!("backend session server bind failed: {error}"));
+                    request_shutdown();
+                    return;
+                }
+            };
+            if let Err(error) = listener.set_nonblocking(true) {
+                emit_host_error(&format!("backend session server setup failed: {error}"));
+                request_shutdown();
+                return;
             }
-            _ => Ok(Box::new(io::stdin())),
+
+            let port = match listener.local_addr() {
+                Ok(addr) => addr.port(),
+                Err(error) => {
+                    emit_host_error(&format!("backend session server address failed: {error}"));
+                    request_shutdown();
+                    return;
+                }
+            };
+            if let Err(error) = write_session_bootstrap(&session_file, port, std::process::id()) {
+                emit_host_error(&format!("backend session bootstrap write failed: {error}"));
+                request_shutdown();
+                return;
+            }
+
+            let (disconnect_tx, disconnect_rx) = mpsc::channel::<usize>();
+            let current_client = Arc::new(AtomicUsize::new(0));
+            let client_connected = Arc::new(AtomicBool::new(false));
+            let mut next_client_id = 0_usize;
+            let mut disconnect_deadline = Some(Instant::now() + initial_connect_grace);
+
+            loop {
+                let mut should_break = false;
+                while let Ok(client_id) = disconnect_rx.try_recv() {
+                    if current_client.load(Ordering::SeqCst) != client_id {
+                        continue;
+                    }
+                    if let Some(runtime) = host_runtime() {
+                        runtime.output.detach_client();
+                    }
+                    client_connected.store(false, Ordering::SeqCst);
+                    if is_shutdown_requested() {
+                        should_break = true;
+                        break;
+                    }
+                    disconnect_deadline = reconnect_grace.map(|grace| Instant::now() + grace);
+                }
+                if should_break {
+                    break;
+                }
+
+                match listener.accept() {
+                    Ok((mut stream, _addr)) => {
+                        if let Err(error) = stream.set_nonblocking(false) {
+                            emit_host_error(&format!(
+                                "backend session stream setup failed: {error}"
+                            ));
+                            request_shutdown();
+                            break;
+                        }
+                        let writer = match stream.try_clone() {
+                            Ok(writer) => writer,
+                            Err(error) => {
+                                emit_host_error(&format!(
+                                    "backend session stream clone failed: {error}"
+                                ));
+                                request_shutdown();
+                                break;
+                            }
+                        };
+                        next_client_id = next_client_id.wrapping_add(1).max(1);
+                        let client_id = next_client_id;
+                        current_client.store(client_id, Ordering::SeqCst);
+                        client_connected.store(true, Ordering::SeqCst);
+                        disconnect_deadline = None;
+                        if let Err(error) = writer.set_nonblocking(false) {
+                            emit_host_error(&format!(
+                                "backend session writer setup failed: {error}"
+                            ));
+                            request_shutdown();
+                            break;
+                        }
+                        if let Some(runtime) = host_runtime() {
+                            runtime.output.attach_client(writer);
+                            emit_attached_client_state(runtime);
+                        }
+
+                        let reader_current_client = Arc::clone(&current_client);
+                        let reader_disconnect_tx = disconnect_tx.clone();
+                        thread::spawn(move || {
+                            loop {
+                                match read_next_command(&mut stream) {
+                                    Ok(Some(command)) => {
+                                        if reader_current_client.load(Ordering::SeqCst) != client_id
+                                        {
+                                            break;
+                                        }
+                                        handle_command(command);
+                                        if is_shutdown_requested() {
+                                            break;
+                                        }
+                                    }
+                                    Ok(None) => break,
+                                    Err(error) => {
+                                        if reader_current_client.load(Ordering::SeqCst) == client_id
+                                            && !is_expected_session_disconnect_error(&error)
+                                        {
+                                            emit_host_error(&format!(
+                                                "backend command read failed: {error}"
+                                            ));
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                            let _ = reader_disconnect_tx.send(client_id);
+                        });
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        if is_shutdown_requested() {
+                            break;
+                        }
+                        if !client_connected.load(Ordering::SeqCst) {
+                            if let Some(deadline) = disconnect_deadline {
+                                if Instant::now() >= deadline {
+                                    request_shutdown();
+                                    break;
+                                }
+                            }
+                        }
+                        thread::sleep(SESSION_ACCEPT_POLL_INTERVAL);
+                    }
+                    Err(error) => {
+                        emit_host_error(&format!("backend session accept failed: {error}"));
+                        request_shutdown();
+                        break;
+                    }
+                }
+            }
+            let _ = fs::remove_file(&session_file);
+        });
+    }
+
+    fn session_transport_config() -> Option<(String, Duration, Option<Duration>)> {
+        let session_file = std::env::var("VSC_R_BACKEND_SESSION_FILE").ok()?;
+        if session_file.trim().is_empty() {
+            return None;
         }
+        let initial_connect_grace_ms = std::env::var("VSC_R_BACKEND_INITIAL_CONNECT_GRACE_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(60_000);
+        let reconnect_grace = std::env::var("VSC_R_BACKEND_RECONNECT_GRACE_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .and_then(|value| {
+                if value == 0 {
+                    None
+                } else {
+                    Some(Duration::from_millis(value))
+                }
+            });
+        Some((
+            session_file,
+            Duration::from_millis(initial_connect_grace_ms),
+            reconnect_grace,
+        ))
+    }
+
+    fn write_session_bootstrap(session_file: &str, port: u16, pid: u32) -> io::Result<()> {
+        let payload = format!("{{\"port\":{port},\"pid\":{pid}}}");
+        fs::write(session_file, payload)
+    }
+
+    fn emit_attached_client_state(runtime: &HostRuntime) {
+        let pid = std::process::id();
+        let _ = runtime.output.flush_backlog();
+        let _ = runtime.output.emit_backend_ready();
+        let _ = runtime.output.emit_host_connected();
+
+        let (busy, wait_state) = {
+            let state = runtime.state.lock().expect("host state lock poisoned");
+            (state.busy, state.wait_state.clone())
+        };
+        let wait = match wait_state {
+            Some(StoredWaitState::TopLevel(kind)) => SessionWaitState::TopLevel(kind),
+            Some(StoredWaitState::Nested(prompt)) => SessionWaitState::Nested(prompt),
+            None => SessionWaitState::None,
+        };
+        let _ = runtime.output.emit_session_state(pid, busy, wait);
+        let _ = runtime.output.emit_output_flush();
+    }
+
+    fn is_expected_session_disconnect_error(error: &io::Error) -> bool {
+        matches!(
+            error.kind(),
+            io::ErrorKind::ConnectionReset
+                | io::ErrorKind::ConnectionAborted
+                | io::ErrorKind::BrokenPipe
+                | io::ErrorKind::UnexpectedEof
+        )
+    }
+
+    fn is_shutdown_requested() -> bool {
+        host_runtime()
+            .map(|runtime| {
+                runtime
+                    .state
+                    .lock()
+                    .expect("host state lock poisoned")
+                    .shutdown_requested
+            })
+            .unwrap_or(false)
     }
 
     fn handle_command(command: IncomingCommand) {
@@ -2236,6 +2732,7 @@ mod windows_host {
             if let Some(fragment) = state.pending_fragment.take() {
                 let signal_input_end = state.pending_fragment_from_nested;
                 state.pending_fragment_from_nested = false;
+                state.wait_state = None;
                 return write_read_buffer(
                     buffer,
                     buflen,
@@ -2281,6 +2778,7 @@ mod windows_host {
             }
 
             if state.shutdown_requested {
+                state.wait_state = None;
                 if matches!(wait_kind, WaitKind::Nested(_)) {
                     let _ = runtime.output.emit_input_end();
                     let _ = runtime.output.emit_output_flush();
@@ -2291,6 +2789,7 @@ mod windows_host {
             if state.interrupt_requested && matches!(wait_kind, WaitKind::Nested(_)) {
                 state.interrupt_requested = false;
                 state.top_level_recovery_pending = Some(TopLevelRecovery::RecoverFromInterrupt);
+                state.wait_state = None;
                 let _ = runtime.output.emit_input_end();
                 let _ = runtime.output.emit_output_flush();
                 READ_CONSOLE_INTERRUPTED.store(true, Ordering::Relaxed);
@@ -2300,10 +2799,12 @@ mod windows_host {
             if !wait_event_emitted {
                 match &wait_kind {
                     WaitKind::TopLevel(kind) => {
+                        state.wait_state = Some(StoredWaitState::TopLevel(*kind));
                         let _ = runtime.output.emit_prompt(*kind);
                         let _ = runtime.output.emit_output_flush();
                     }
                     WaitKind::Nested(prompt) => {
+                        state.wait_state = Some(StoredWaitState::Nested(prompt.clone()));
                         let _ = runtime.output.emit_input_request(prompt);
                         let _ = runtime.output.emit_output_flush();
                     }
@@ -2380,6 +2881,8 @@ mod windows_host {
                     state.suppress_idle_event_pump = state.interrupt_requested;
                     state.interrupt_requested = false;
                     set_r_interrupts_pending(false);
+                } else {
+                    state.wait_state = None;
                 }
                 should_preserve_interrupt = value != 0 && state.interrupt_requested;
             }
@@ -2464,6 +2967,7 @@ mod windows_host {
 
     fn take_next_line(wait_kind: &WaitKind, state: &mut SharedState) -> Option<PendingLine> {
         if let Some(line) = state.active_submission_lines.pop_front() {
+            state.wait_state = None;
             return Some(PendingLine {
                 bytes: line,
                 signal_input_end: false,
@@ -2479,6 +2983,7 @@ mod windows_host {
                 match state.pending_commands.remove(index) {
                     Some(PendingCommand::Submit(lines)) => {
                         state.active_submission_lines = lines;
+                        state.wait_state = None;
                         state
                             .active_submission_lines
                             .pop_front()
@@ -2496,10 +3001,13 @@ mod windows_host {
                     .iter()
                     .position(|command| matches!(command, PendingCommand::Reply(_)))?;
                 match state.pending_commands.remove(index) {
-                    Some(PendingCommand::Reply(bytes)) => Some(PendingLine {
-                        bytes,
-                        signal_input_end: true,
-                    }),
+                    Some(PendingCommand::Reply(bytes)) => {
+                        state.wait_state = None;
+                        Some(PendingLine {
+                            bytes,
+                            signal_input_end: true,
+                        })
+                    }
                     _ => None,
                 }
             }

--- a/sidecar/pty-host/src/host.rs
+++ b/sidecar/pty-host/src/host.rs
@@ -1583,7 +1583,10 @@ mod unix_host {
                 *value = 1;
             }
             if let Some(value) = self.r_signal_handlers {
-                *value = 0;
+                // Unix busy interrupts use SIGINT to wake R. Keep R's signal
+                // handler installed so SIGINT is converted into a user
+                // interrupt instead of terminating the host process.
+                *value = 1;
             }
 
             let mut argv_storage = build_r_args(r_executable, r_args)?;

--- a/sidecar/pty-host/src/host.rs
+++ b/sidecar/pty-host/src/host.rs
@@ -28,6 +28,7 @@ mod unix_host {
     const CONT_PROMPT: &str = "+ ";
     const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(50);
     const SESSION_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+    const MAX_ACTIVITY_HANDLER_DRAIN: usize = 64;
 
     const SUPPORTED_CAPABILITIES: &[&str] = &[
         "control-channel",
@@ -653,6 +654,18 @@ mod unix_host {
         }
     }
 
+    fn preserve_requested_interrupt() -> bool {
+        let Some(runtime) = host_runtime() else {
+            return false;
+        };
+        let state = runtime.state.lock().expect("host state lock poisoned");
+        if !state.interrupt_requested {
+            return false;
+        }
+        set_r_interrupts_pending(true);
+        true
+    }
+
     fn host_runtime() -> Option<&'static HostRuntime> {
         HOST_RUNTIME.get()
     }
@@ -806,10 +819,12 @@ mod unix_host {
     unsafe fn run_process_events(api: EventLoopApi) {
         if let Some(process_events) = api.r_process_events {
             process_events();
+            preserve_requested_interrupt();
         }
         run_activity_handlers(api);
         if let Some(run_pending_finalizers) = api.r_run_pending_finalizers {
             run_pending_finalizers();
+            preserve_requested_interrupt();
         }
     }
 
@@ -819,9 +834,14 @@ mod unix_host {
             return;
         }
 
+        let mut handled = 0_usize;
         let mut mask = (api.r_check_activity)(0, 1);
-        while !mask.is_null() {
+        while !mask.is_null() && handled < MAX_ACTIVITY_HANDLER_DRAIN {
             (api.r_run_handlers)(handlers, mask);
+            handled += 1;
+            if preserve_requested_interrupt() {
+                break;
+            }
             mask = (api.r_check_activity)(0, 1);
         }
     }
@@ -841,6 +861,7 @@ mod unix_host {
         };
 
         run_activity_handlers(api);
+        preserve_requested_interrupt();
     }
 
     unsafe extern "C-unwind" fn polled_events_callback() {
@@ -849,6 +870,7 @@ mod unix_host {
         };
 
         run_activity_handlers(api);
+        preserve_requested_interrupt();
     }
 
     unsafe extern "C-unwind" fn read_console_callback(
@@ -1733,6 +1755,7 @@ mod windows_host {
     const CONT_PROMPT: &str = "+ ";
     const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(50);
     const SESSION_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+    const MAX_ACTIVITY_HANDLER_DRAIN: usize = 64;
     const EMBEDDED_UTF8_PREFIX: &[u8] = &[0x02, 0xff, 0xfe];
     const EMBEDDED_UTF8_SUFFIX: &[u8] = &[0x03, 0xff, 0xfe];
 
@@ -2443,6 +2466,18 @@ mod windows_host {
         }
     }
 
+    fn preserve_requested_interrupt() -> bool {
+        let Some(runtime) = host_runtime() else {
+            return false;
+        };
+        let state = runtime.state.lock().expect("host state lock poisoned");
+        if !state.interrupt_requested {
+            return false;
+        }
+        set_r_interrupts_pending(true);
+        true
+    }
+
     fn host_runtime() -> Option<&'static HostRuntime> {
         HOST_RUNTIME.get()
     }
@@ -2610,9 +2645,14 @@ mod windows_host {
             return;
         }
 
+        let mut handled = 0_usize;
         let mut mask = check_activity(0, 1);
-        while !mask.is_null() {
+        while !mask.is_null() && handled < MAX_ACTIVITY_HANDLER_DRAIN {
             run_handlers(handlers, mask);
+            handled += 1;
+            if preserve_requested_interrupt() {
+                break;
+            }
             mask = check_activity(0, 1);
         }
     }
@@ -2624,10 +2664,12 @@ mod windows_host {
         pump_windows_messages();
         if let Some(process_events) = api.r_process_events {
             process_events();
+            preserve_requested_interrupt();
         }
         run_activity_handlers(api);
         if let Some(run_pending_finalizers) = api.r_run_pending_finalizers {
             run_pending_finalizers();
+            preserve_requested_interrupt();
         }
     }
 
@@ -2643,19 +2685,20 @@ mod windows_host {
         if let Some(api) = event_loop_api() {
             if !PROCESS_EVENTS_CALLBACK_ACTIVE.swap(true, Ordering::AcqRel) {
                 if let Some(peek_event) = api.ga_peekevent {
-                    while peek_event() != 0 {}
+                    let mut handled = 0_usize;
+                    while handled < MAX_ACTIVITY_HANDLER_DRAIN && peek_event() != 0 {
+                        handled += 1;
+                        if preserve_requested_interrupt() {
+                            break;
+                        }
+                    }
                 }
                 pump_windows_messages();
                 run_activity_handlers(api);
                 PROCESS_EVENTS_CALLBACK_ACTIVE.store(false, Ordering::Release);
             }
         }
-        if let Some(runtime) = host_runtime() {
-            let state = runtime.state.lock().expect("host state lock poisoned");
-            if state.interrupt_requested {
-                set_r_interrupts_pending(true);
-            }
-        }
+        preserve_requested_interrupt();
     }
 
     unsafe extern "C-unwind" fn polled_events_callback() {
@@ -2666,6 +2709,7 @@ mod windows_host {
                 PROCESS_EVENTS_CALLBACK_ACTIVE.store(false, Ordering::Release);
             }
         }
+        preserve_requested_interrupt();
     }
 
     unsafe extern "C-unwind" fn read_console_callback(

--- a/sidecar/pty-host/src/main.rs
+++ b/sidecar/pty-host/src/main.rs
@@ -2,8 +2,104 @@ mod host;
 mod protocol;
 
 fn main() {
-    if let Err(error) = host::run(std::env::args().skip(1).collect()) {
+    #[cfg(windows)]
+    if let Err(error) = windows_launch_or_run_real_host() {
         eprintln!("R_CONSOLE_HOST error: {error}");
         std::process::exit(1);
     }
+
+    #[cfg(windows)]
+    return;
+
+    #[cfg(not(windows))]
+    run_host(std::env::args().skip(1).collect());
+}
+
+fn run_host(args: Vec<String>) {
+    if let Err(error) = host::run(args) {
+        eprintln!("R_CONSOLE_HOST error: {error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(windows)]
+fn windows_launch_or_run_real_host() -> Result<(), Box<dyn std::error::Error>> {
+    const REAL_HOST_ENV: &str = "VSC_R_CONSOLE_REAL_HOST";
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if std::env::var_os(REAL_HOST_ENV).is_some() {
+        unsafe {
+            // The real sidecar owns the embedded R session and TCP server. It
+            // must not remain attached to VS Code's console-control group.
+            let _ = windows_sys::Win32::System::Console::FreeConsole();
+        }
+        run_host(args);
+        return Ok(());
+    }
+
+    use windows_sys::Win32::System::Threading::{
+        CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS,
+    };
+
+    let exe = std::env::current_exe()?;
+    let base_flags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW;
+    let breakaway_flags = base_flags | CREATE_BREAKAWAY_FROM_JOB;
+
+    let mut child = spawn_windows_real_host(&exe, &args, REAL_HOST_ENV, breakaway_flags)
+        .or_else(|_| spawn_windows_real_host(&exe, &args, REAL_HOST_ENV, base_flags))?;
+    wait_for_windows_real_host_bootstrap(&mut child)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn spawn_windows_real_host(
+    exe: &std::path::Path,
+    args: &[String],
+    real_host_env: &str,
+    creation_flags: u32,
+) -> std::io::Result<std::process::Child> {
+    use std::os::windows::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let mut command = Command::new(exe);
+    command
+        .args(args)
+        .env(real_host_env, "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .creation_flags(creation_flags);
+    command.spawn()
+}
+
+#[cfg(windows)]
+fn wait_for_windows_real_host_bootstrap(
+    child: &mut std::process::Child,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    let session_file = std::env::var("VSC_R_BACKEND_SESSION_FILE")?;
+    let initial_connect_grace_ms = std::env::var("VSC_R_BACKEND_INITIAL_CONNECT_GRACE_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(60_000);
+    let deadline = Instant::now() + Duration::from_millis(initial_connect_grace_ms);
+
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait()? {
+            return Err(format!("real R console host exited before bootstrap: {status}").into());
+        }
+
+        if let Ok(payload) = fs::read_to_string(&session_file) {
+            if payload.contains("\"port\":") && payload.contains("\"pid\":") {
+                return Ok(());
+            }
+        }
+
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    Err(format!("timed out waiting for real R console host bootstrap at {session_file}").into())
 }

--- a/sidecar/pty-host/src/protocol.rs
+++ b/sidecar/pty-host/src/protocol.rs
@@ -1,5 +1,8 @@
+use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex};
+#[cfg(any(unix, windows))]
+use std::thread;
 #[cfg(unix)]
 use std::{fs::File, os::fd::FromRawFd};
 #[cfg(windows)]
@@ -7,13 +10,12 @@ use std::{fs::File, os::windows::io::FromRawHandle};
 #[cfg(windows)]
 use windows_sys::Win32::{
     Foundation::{
-        DuplicateHandle, SetHandleInformation, DUPLICATE_SAME_ACCESS, HANDLE,
+        CloseHandle, DuplicateHandle, SetHandleInformation, DUPLICATE_SAME_ACCESS, HANDLE,
         HANDLE_FLAG_INHERIT,
     },
     System::{
-        Console::{
-            GetStdHandle, SetStdHandle, STD_ERROR_HANDLE, STD_OUTPUT_HANDLE,
-        },
+        Console::{GetStdHandle, SetStdHandle, STD_ERROR_HANDLE, STD_HANDLE, STD_OUTPUT_HANDLE},
+        Pipes::CreatePipe,
         Threading::GetCurrentProcess,
     },
 };
@@ -23,7 +25,6 @@ pub(crate) const PROTOCOL_VERSION: u32 = 1;
 
 const FRAME_BACKEND_READY: u16 = 1;
 const FRAME_HOST_CONNECTED: u16 = 2;
-const FRAME_CHILD_SPAWNED: u16 = 3;
 const FRAME_PROMPT: u16 = 4;
 const FRAME_BUSY: u16 = 5;
 const FRAME_INPUT_REQUEST: u16 = 6;
@@ -40,6 +41,9 @@ const FRAME_DIALOG_REQUEST: u16 = 16;
 const FRAME_SHUTDOWN: u16 = 17;
 const FRAME_DIALOG_RESULT: u16 = 18;
 const FRAME_HOST_ERROR: u16 = 19;
+const FRAME_SESSION_STATE: u16 = 20;
+const MAX_BUFFERED_FRAMES: usize = 4096;
+const MAX_BUFFERED_BYTES: usize = 1_000_000;
 
 #[derive(Debug)]
 pub(crate) enum DialogRequest {
@@ -73,15 +77,35 @@ pub(crate) enum OutputStream {
 }
 
 pub(crate) struct OutputSink {
-    stdout: Arc<Mutex<Box<dyn Write + Send>>>,
+    output_state: Arc<Mutex<OutputChannelState>>,
     host_name: Arc<String>,
     capabilities: Arc<Vec<String>>,
+}
+
+struct OutputChannelState {
+    writer: Option<Box<dyn Write + Send>>,
+    backlog: VecDeque<Vec<u8>>,
+    backlog_bytes: usize,
+}
+
+pub(crate) enum SessionWaitState {
+    None,
+    TopLevel(PromptKind),
+    Nested(String),
 }
 
 impl OutputSink {
     pub(crate) fn new_with_capabilities(host_name: &str, capabilities: &[&str]) -> Self {
         Self {
-            stdout: Arc::new(Mutex::new(create_protocol_writer())),
+            output_state: Arc::new(Mutex::new(OutputChannelState {
+                writer: if session_transport_enabled() {
+                    None
+                } else {
+                    Some(create_protocol_writer())
+                },
+                backlog: VecDeque::new(),
+                backlog_bytes: 0,
+            })),
             host_name: Arc::new(host_name.to_string()),
             capabilities: Arc::new(
                 capabilities
@@ -94,10 +118,17 @@ impl OutputSink {
 
     pub(crate) fn clone_handle(&self) -> Self {
         Self {
-            stdout: Arc::clone(&self.stdout),
+            output_state: Arc::clone(&self.output_state),
             host_name: Arc::clone(&self.host_name),
             capabilities: Arc::clone(&self.capabilities),
         }
+    }
+
+    pub(crate) fn capture_process_stdout(&self) -> io::Result<()> {
+        if !session_transport_enabled() {
+            return Ok(());
+        }
+        capture_process_stdout_to_sink(self.clone_handle())
     }
 
     pub(crate) fn emit_backend_ready(&self) -> io::Result<()> {
@@ -119,10 +150,6 @@ impl OutputSink {
             &mut payload,
         );
         self.emit_frame(FRAME_HOST_CONNECTED, 0, &payload)
-    }
-
-    pub(crate) fn emit_child_spawned(&self, pid: u32) -> io::Result<()> {
-        self.emit_frame(FRAME_CHILD_SPAWNED, 0, &pid.to_le_bytes())
     }
 
     pub(crate) fn emit_prompt(&self, kind: PromptKind) -> io::Result<()> {
@@ -185,23 +212,115 @@ impl OutputSink {
         self.emit_frame(FRAME_HOST_ERROR, 0, message.as_bytes())
     }
 
-    fn emit_frame(&self, kind: u16, request_id: u32, payload: &[u8]) -> io::Result<()> {
-        let mut header = [0_u8; FRAME_HEADER_LEN];
-        header[0..4].copy_from_slice(&(payload.len() as u32).to_le_bytes());
-        header[4..6].copy_from_slice(&kind.to_le_bytes());
-        header[6..8].copy_from_slice(&0_u16.to_le_bytes());
-        header[8..12].copy_from_slice(&request_id.to_le_bytes());
+    pub(crate) fn emit_session_state(
+        &self,
+        pid: u32,
+        busy: bool,
+        wait: SessionWaitState,
+    ) -> io::Result<()> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&pid.to_le_bytes());
+        payload.push(if busy { 1 } else { 0 });
+        match wait {
+            SessionWaitState::None => payload.push(0),
+            SessionWaitState::TopLevel(PromptKind::Main) => payload.push(1),
+            SessionWaitState::TopLevel(PromptKind::Cont) => payload.push(2),
+            SessionWaitState::Nested(prompt) => {
+                payload.push(3);
+                payload.extend_from_slice(prompt.as_bytes());
+            }
+        }
+        self.emit_frame(FRAME_SESSION_STATE, 0, &payload)
+    }
 
-        let mut stdout = self
-            .stdout
+    pub(crate) fn attach_client<W: Write + Send + 'static>(&self, writer: W) {
+        if let Ok(mut output_state) = self.output_state.lock() {
+            output_state.writer = Some(Box::new(writer));
+        }
+    }
+
+    pub(crate) fn detach_client(&self) {
+        if let Ok(mut output_state) = self.output_state.lock() {
+            output_state.writer = None;
+        }
+    }
+
+    pub(crate) fn flush_backlog(&self) -> io::Result<()> {
+        let mut output_state = self
+            .output_state
             .lock()
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "stdout lock poisoned"))?;
-        stdout.write_all(&header)?;
-        if !payload.is_empty() {
-            stdout.write_all(payload)?;
+        let Some(mut writer) = output_state.writer.take() else {
+            return Ok(());
+        };
+        let mut backlog = std::mem::take(&mut output_state.backlog);
+        output_state.backlog_bytes = 0;
+
+        while let Some(frame) = backlog.pop_front() {
+            if let Err(err) = writer.write_all(&frame) {
+                queue_backlog_frame(&mut output_state, frame);
+                while let Some(remaining) = backlog.pop_front() {
+                    queue_backlog_frame(&mut output_state, remaining);
+                }
+                return Err(err);
+            }
         }
-        stdout.flush()
+        if let Err(err) = writer.flush() {
+            while let Some(remaining) = backlog.pop_front() {
+                queue_backlog_frame(&mut output_state, remaining);
+            }
+            return Err(err);
+        }
+
+        output_state.writer = Some(writer);
+        Ok(())
     }
+
+    fn emit_frame(&self, kind: u16, request_id: u32, payload: &[u8]) -> io::Result<()> {
+        let mut frame = Vec::with_capacity(FRAME_HEADER_LEN + payload.len());
+        frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        frame.extend_from_slice(&kind.to_le_bytes());
+        frame.extend_from_slice(&0_u16.to_le_bytes());
+        frame.extend_from_slice(&request_id.to_le_bytes());
+        frame.extend_from_slice(payload);
+
+        let mut output_state = self
+            .output_state
+            .lock()
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "stdout lock poisoned"))?;
+        if let Some(writer) = output_state.writer.as_mut() {
+            match writer.write_all(&frame).and_then(|_| writer.flush()) {
+                Ok(()) => return Ok(()),
+                Err(_) => {
+                    output_state.writer = None;
+                }
+            }
+        }
+
+        queue_backlog_frame(&mut output_state, frame);
+        Ok(())
+    }
+}
+
+fn queue_backlog_frame(output_state: &mut OutputChannelState, frame: Vec<u8>) {
+    output_state.backlog_bytes += frame.len();
+    output_state.backlog.push_back(frame);
+    while output_state.backlog.len() > MAX_BUFFERED_FRAMES
+        || output_state.backlog_bytes > MAX_BUFFERED_BYTES
+    {
+        if let Some(removed) = output_state.backlog.pop_front() {
+            output_state.backlog_bytes = output_state.backlog_bytes.saturating_sub(removed.len());
+        } else {
+            break;
+        }
+    }
+}
+
+fn session_transport_enabled() -> bool {
+    matches!(
+        std::env::var("VSC_R_BACKEND_SESSION_FILE"),
+        Ok(value) if !value.trim().is_empty()
+    )
 }
 
 #[cfg(unix)]
@@ -232,6 +351,65 @@ fn create_protocol_writer() -> Box<dyn Write + Send> {
     }
 
     Box::new(io::stdout())
+}
+
+#[cfg(unix)]
+fn capture_process_stdout_to_sink(output: OutputSink) -> io::Result<()> {
+    capture_unix_fd_to_sink(
+        output.clone_handle(),
+        libc::STDOUT_FILENO,
+        OutputStream::Stdout,
+    )?;
+    capture_unix_fd_to_sink(output, libc::STDERR_FILENO, OutputStream::Stderr)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn capture_unix_fd_to_sink(
+    output: OutputSink,
+    fd: libc::c_int,
+    stream: OutputStream,
+) -> io::Result<()> {
+    unsafe {
+        let mut fds = [0; 2];
+        if libc::pipe(fds.as_mut_ptr()) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let read_fd = fds[0];
+        let write_fd = fds[1];
+
+        let read_flags = libc::fcntl(read_fd, libc::F_GETFD);
+        if read_flags >= 0 {
+            let _ = libc::fcntl(read_fd, libc::F_SETFD, read_flags | libc::FD_CLOEXEC);
+        }
+
+        if libc::dup2(write_fd, fd) < 0 {
+            let error = io::Error::last_os_error();
+            let _ = libc::close(read_fd);
+            let _ = libc::close(write_fd);
+            return Err(error);
+        }
+        let _ = libc::close(write_fd);
+
+        thread::spawn(move || {
+            let mut reader = File::from_raw_fd(read_fd);
+            let mut buffer = [0_u8; 8192];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(count) => {
+                        let _ = output.emit_output(stream, &buffer[..count]);
+                        let _ = output.emit_output_flush();
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+
+    Ok(())
 }
 
 #[cfg(not(unix))]
@@ -269,6 +447,82 @@ fn create_protocol_writer() -> Box<dyn Write + Send> {
     }
 
     Box::new(io::stdout())
+}
+
+#[cfg(windows)]
+fn capture_process_stdout_to_sink(output: OutputSink) -> io::Result<()> {
+    capture_windows_fd_to_sink(
+        output.clone_handle(),
+        1,
+        STD_OUTPUT_HANDLE,
+        OutputStream::Stdout,
+    )?;
+    capture_windows_fd_to_sink(output, 2, STD_ERROR_HANDLE, OutputStream::Stderr)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn capture_windows_fd_to_sink(
+    output: OutputSink,
+    fd: libc::c_int,
+    std_handle: STD_HANDLE,
+    stream: OutputStream,
+) -> io::Result<()> {
+    unsafe {
+        let mut read_handle: HANDLE = std::ptr::null_mut();
+        let mut write_handle: HANDLE = std::ptr::null_mut();
+        if CreatePipe(&mut read_handle, &mut write_handle, std::ptr::null(), 0) == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let _ = SetHandleInformation(read_handle, HANDLE_FLAG_INHERIT, 0);
+        let _ = SetHandleInformation(write_handle, HANDLE_FLAG_INHERIT, 0);
+
+        let write_fd = libc::open_osfhandle(write_handle as libc::intptr_t, libc::O_BINARY);
+        if write_fd < 0 {
+            let error = io::Error::last_os_error();
+            let _ = CloseHandle(read_handle);
+            let _ = CloseHandle(write_handle);
+            return Err(error);
+        }
+
+        if libc::dup2(write_fd, fd) < 0 {
+            let error = io::Error::last_os_error();
+            let _ = libc::close(write_fd);
+            let _ = CloseHandle(read_handle);
+            return Err(error);
+        }
+        let _ = libc::close(write_fd);
+
+        let redirected_handle = libc::get_osfhandle(fd);
+        if redirected_handle >= 0 {
+            let _ = SetStdHandle(std_handle, redirected_handle as HANDLE);
+        }
+
+        let read_handle_value = read_handle as isize;
+        thread::spawn(move || {
+            let mut reader = File::from_raw_handle(read_handle_value as _);
+            let mut buffer = [0_u8; 8192];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(count) => {
+                        let _ = output.emit_output(stream, &buffer[..count]);
+                        let _ = output.emit_output_flush();
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn capture_process_stdout_to_sink(_output: OutputSink) -> io::Result<()> {
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/Runtime/backendProtocol.ts
+++ b/src/Runtime/backendProtocol.ts
@@ -3,7 +3,6 @@ const FRAME_HEADER_LEN = 12;
 const FrameKind = {
   BackendReady: 1,
   HostConnected: 2,
-  ChildSpawned: 3,
   Prompt: 4,
   Busy: 5,
   InputRequest: 6,
@@ -20,6 +19,7 @@ const FrameKind = {
   Shutdown: 17,
   DialogResult: 18,
   HostError: 19,
+  SessionState: 20,
 } as const;
 
 export type BackendCapability =
@@ -72,10 +72,6 @@ export type BackendControlEvent =
       capabilities: BackendCapability[];
     }
   | {
-      type: "child-spawned";
-      pid?: number;
-    }
-  | {
       type: "prompt";
       kind: "main" | "cont";
     }
@@ -105,6 +101,23 @@ export type BackendControlEvent =
   | {
       type: "host-error";
       message: string;
+    }
+  | {
+      type: "session-state";
+      pid?: number;
+      busy: boolean;
+      wait:
+        | {
+            kind: "none";
+          }
+        | {
+            kind: "top-level";
+            prompt: "main" | "cont";
+          }
+        | {
+            kind: "nested";
+            prompt: string;
+          };
     };
 
 type BackendFrameParseResult = {
@@ -249,17 +262,6 @@ function parseControlFrame(
         capabilities: info.capabilities,
       };
     }
-    case FrameKind.ChildSpawned:
-      if (payload.length === 0) {
-        return { type: "child-spawned" };
-      }
-      if (payload.length !== 4) {
-        throw new Error("invalid child-spawned payload");
-      }
-      return {
-        type: "child-spawned",
-        pid: payload.readUInt32LE(0),
-      };
     case FrameKind.Prompt:
       if (payload.length !== 1) {
         throw new Error("invalid prompt payload");
@@ -301,6 +303,46 @@ function parseControlFrame(
         type: "host-error",
         message: payload.toString("utf8"),
       };
+    case FrameKind.SessionState: {
+      if (payload.length < 6) {
+        throw new Error("invalid session-state payload");
+      }
+      const pid = payload.readUInt32LE(0);
+      const busy = payload[4] !== 0;
+      const waitKind = payload[5];
+      if (waitKind === 0) {
+        return {
+          type: "session-state",
+          pid: pid > 0 ? pid : undefined,
+          busy,
+          wait: { kind: "none" },
+        };
+      }
+      if (waitKind === 1 || waitKind === 2) {
+        return {
+          type: "session-state",
+          pid: pid > 0 ? pid : undefined,
+          busy,
+          wait: {
+            kind: "top-level",
+            prompt: waitKind === 2 ? "cont" : "main",
+          },
+        };
+      }
+      if (waitKind === 3) {
+        const prompt = payload.toString("utf8", 6);
+        return {
+          type: "session-state",
+          pid: pid > 0 ? pid : undefined,
+          busy,
+          wait: {
+            kind: "nested",
+            prompt,
+          },
+        };
+      }
+      throw new Error(`unknown session-state kind ${waitKind}`);
+    }
     default:
       return undefined;
   }

--- a/src/Runtime/runtimeBackend.ts
+++ b/src/Runtime/runtimeBackend.ts
@@ -485,6 +485,9 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
           return;
         }
         this.resolvePendingParseRequests(state, 1);
+        if (state.hostConnected && isSocketDisconnectError(error)) {
+          return;
+        }
         state.handlers?.onError?.(error instanceof Error ? error : new Error(String(error)));
       });
 
@@ -492,10 +495,11 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
         if (state.socket !== socket) {
           return;
         }
+        const wasHostConnected = state.hostConnected;
         state.socket = undefined;
         state.hostConnected = false;
         this.resolvePendingParseRequests(state, 1);
-        if (!state.explicitClose && !state.child) {
+        if (!state.explicitClose && wasHostConnected) {
           state.handlers?.onExit?.(0);
         }
       });
@@ -795,6 +799,11 @@ function isRuntimeSessionPidAlive(pid: number | undefined): boolean {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code !== "ESRCH";
   }
+}
+
+function isSocketDisconnectError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ECONNRESET" || code === "EPIPE";
 }
 
 function cleanupRuntimeSessionBootstrapFile(sessionId: string): void {

--- a/src/Runtime/runtimeBackend.ts
+++ b/src/Runtime/runtimeBackend.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "crypto";
 import { ChildProcess, spawn, SpawnOptions } from "child_process";
 import * as fs from "fs";
 import * as net from "net";
+import * as os from "os";
 import * as path from "path";
 import {
   type BackendCapability,
@@ -47,12 +49,19 @@ type RuntimeSessionCommand =
       result: BackendDialogResult;
     };
 
-type BackendProcessState = {
+export type RuntimeSessionReconnectInfo = {
+  sessionId: string;
+  port: number;
+  pid?: number;
+};
+
+export type RuntimeSessionHandle = {
+  readonly sessionId: string;
+};
+
+type BackendSessionState = {
   capabilities: Set<BackendCapability>;
   hostConnected: boolean;
-  commandServer?: net.Server;
-  commandSocket?: net.Socket;
-  pendingCommandFrames: Buffer[];
   nextRequestId: number;
   pendingParseRequests: Map<
     number,
@@ -62,179 +71,197 @@ type BackendProcessState = {
       timeout: NodeJS.Timeout;
     }
   >;
+  child?: ChildProcess;
+  childListenersAttached: boolean;
+  sessionFilePath?: string;
+  reconnectInfo: Partial<RuntimeSessionReconnectInfo> & Pick<RuntimeSessionReconnectInfo, "sessionId">;
+  socket?: net.Socket;
+  socketCarry: Buffer;
+  explicitClose: boolean;
+  attachGeneration: number;
+  handlers?: RuntimeBackendHandlers;
+};
+
+type SessionBootstrapFile = {
+  port?: number;
+  pid?: number;
 };
 
 const PARSE_STATUS_TIMEOUT_MS = 150;
+const SESSION_BOOTSTRAP_TIMEOUT_MS = 5000;
+const SESSION_BOOTSTRAP_POLL_MS = 40;
+const INITIAL_CONNECT_GRACE_MS = 60000;
+const PERSISTENT_RECONNECT_GRACE_MS = 0;
+const RECONNECT_SOCKET_RETRY_MS = 100;
 
 export interface RuntimeBackend {
-  start(args: string[], options: RuntimeBackendStartOptions): ChildProcess;
-  attach(process: ChildProcess, handlers: RuntimeBackendHandlers): void;
-  hasCapability(process: ChildProcess | null, capability: BackendCapability): boolean;
-  canUseSessionCommands(process: ChildProcess | null): boolean;
-  sendSessionCommand(process: ChildProcess | null, command: RuntimeSessionCommand): boolean;
-  requestParseStatus(process: ChildProcess | null, code: string): Promise<number> | undefined;
-  close(process: ChildProcess): void;
+  start(args: string[], options: RuntimeBackendStartOptions): RuntimeSessionHandle;
+  reconnect(info: RuntimeSessionReconnectInfo): RuntimeSessionHandle;
+  attach(session: RuntimeSessionHandle, handlers: RuntimeBackendHandlers): void;
+  hasCapability(session: RuntimeSessionHandle | null, capability: BackendCapability): boolean;
+  canUseSessionCommands(session: RuntimeSessionHandle | null): boolean;
+  sendSessionCommand(session: RuntimeSessionHandle | null, command: RuntimeSessionCommand): boolean;
+  requestParseStatus(session: RuntimeSessionHandle | null, code: string): Promise<number> | undefined;
+  close(session: RuntimeSessionHandle): void;
+  isAlive(session: RuntimeSessionHandle | null): boolean;
+  getPid(session: RuntimeSessionHandle | null): number | undefined;
+  getReconnectInfo(session: RuntimeSessionHandle | null): RuntimeSessionReconnectInfo | undefined;
 }
 
 export class RustSidecarRuntimeBackend implements RuntimeBackend {
-  private readonly processStates = new WeakMap<ChildProcess, BackendProcessState>();
+  private readonly sessionStates = new WeakMap<RuntimeSessionHandle, BackendSessionState>();
 
   constructor(private readonly sidecarPath: string) {}
 
-  start(args: string[], options: RuntimeBackendStartOptions): ChildProcess {
-    const state: BackendProcessState = {
-      capabilities: new Set<BackendCapability>(),
-      hostConnected: false,
-      pendingCommandFrames: [],
-      nextRequestId: 0,
-      pendingParseRequests: new Map(),
-    };
+  start(args: string[], options: RuntimeBackendStartOptions): RuntimeSessionHandle {
+    const sessionId = randomUUID();
+    const sessionFilePath = getSessionBootstrapFilePath(sessionId);
+    try {
+      fs.rmSync(sessionFilePath, { force: true });
+    } catch {
+    }
+
     const spawnOptions: SpawnOptions = {
       cwd: options.cwd,
-      env: { ...options.env },
-      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...options.env,
+        VSC_R_BACKEND_SESSION_FILE: sessionFilePath,
+        VSC_R_BACKEND_INITIAL_CONNECT_GRACE_MS: String(INITIAL_CONNECT_GRACE_MS),
+        VSC_R_BACKEND_RECONNECT_GRACE_MS: String(PERSISTENT_RECONNECT_GRACE_MS),
+      },
+      detached: true,
+      stdio: ["ignore", "ignore", "ignore"],
+      windowsHide: true,
     };
 
-    if (process.platform === "win32") {
-      const commandPipePath = createBackendCommandPipePath();
-      const server = net.createServer((socket) => {
-        state.commandSocket = socket;
-        socket.on("error", () => {
-          if (state.commandSocket === socket) {
-            state.commandSocket = undefined;
-          }
-        });
-        socket.on("close", () => {
-          if (state.commandSocket === socket) {
-            state.commandSocket = undefined;
-          }
-        });
-        for (const frame of state.pendingCommandFrames) {
-          socket.write(frame);
-        }
-        state.pendingCommandFrames = [];
-      });
-      server.on("error", () => {
-        state.commandSocket?.destroy();
-        state.commandSocket = undefined;
-      });
-      server.listen(commandPipePath);
-      state.commandServer = server;
-      spawnOptions.env = {
-        ...spawnOptions.env,
-        VSC_R_BACKEND_COMMAND_PIPE: commandPipePath,
-      };
-      spawnOptions.stdio = ["ignore", "pipe", "pipe"];
-    }
+    const child = spawn(this.sidecarPath, args, spawnOptions);
+    child.unref();
+    const handle: RuntimeSessionHandle = {
+      sessionId,
+    };
 
-    try {
-      const child = spawn(this.sidecarPath, args, spawnOptions);
-      this.processStates.set(child, state);
-      return child;
-    } catch (error) {
-      state.commandSocket?.destroy();
-      state.commandSocket = undefined;
-      state.commandServer?.close();
-      state.commandServer = undefined;
-      throw error;
-    }
+    this.sessionStates.set(handle, {
+      capabilities: new Set<BackendCapability>(),
+      hostConnected: false,
+      nextRequestId: 0,
+      pendingParseRequests: new Map(),
+      child,
+      childListenersAttached: false,
+      sessionFilePath,
+      reconnectInfo: { sessionId },
+      socketCarry: Buffer.alloc(0),
+      explicitClose: false,
+      attachGeneration: 0,
+    });
+
+    return handle;
   }
 
-  attach(process: ChildProcess, handlers: RuntimeBackendHandlers): void {
-    const state = this.getOrCreateState(process);
-    let stdoutCarry: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  reconnect(info: RuntimeSessionReconnectInfo): RuntimeSessionHandle {
+    const handle: RuntimeSessionHandle = {
+      sessionId: info.sessionId,
+    };
 
-    process.stdout?.on("data", (chunk: Buffer | string) => {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "binary");
-      const parsed = parseBackendFrames(buffer, stdoutCarry);
-      stdoutCarry = parsed.carry;
-
-      if (parsed.error) {
-        handlers.onError?.(new Error(parsed.error));
-        return;
-      }
-
-      for (const outputChunk of parsed.output) {
-        if (outputChunk.data.length === 0) {
-          continue;
-        }
-
-        const text = outputChunk.data.toString("utf8");
-        if (outputChunk.stream === "stderr") {
-          handlers.onStderr?.(text);
-        } else {
-          handlers.onStdout?.(text);
-        }
-      }
-
-      for (const event of parsed.events) {
-        this.handleProcessControlEvent(state, event);
-        handlers.onControl?.(event);
-      }
+    this.sessionStates.set(handle, {
+      capabilities: new Set<BackendCapability>(),
+      hostConnected: false,
+      nextRequestId: 0,
+      pendingParseRequests: new Map(),
+      childListenersAttached: false,
+      sessionFilePath: getSessionBootstrapFilePath(info.sessionId),
+      reconnectInfo: { ...info },
+      socketCarry: Buffer.alloc(0),
+      explicitClose: false,
+      attachGeneration: 0,
     });
 
-    process.stderr?.on("data", (chunk: Buffer | string) => {
-      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
-      handlers.onStderr?.(text);
-    });
-
-    process.on("exit", (code) => {
-      state.commandSocket?.destroy();
-      state.commandSocket = undefined;
-      state.commandServer?.close();
-      state.commandServer = undefined;
-      if (stdoutCarry.length > 0) {
-        handlers.onStderr?.(
-          `[r-console] truncated backend frame stream (${stdoutCarry.length} buffered bytes left)\n`
-        );
-        stdoutCarry = Buffer.alloc(0);
-      }
-      this.resolvePendingParseRequests(state, 1);
-      handlers.onExit?.(code ?? 0);
-    });
-
-    process.on("error", (error) => {
-      state.commandSocket?.destroy();
-      state.commandSocket = undefined;
-      state.commandServer?.close();
-      state.commandServer = undefined;
-      this.resolvePendingParseRequests(state, 1);
-      handlers.onError?.(error instanceof Error ? error : new Error(String(error)));
-    });
+    return handle;
   }
 
-  canUseSessionCommands(process: ChildProcess | null): boolean {
-    if (!process) {
+  attach(session: RuntimeSessionHandle, handlers: RuntimeBackendHandlers): void {
+    const state = this.getOrCreateState(session);
+    state.explicitClose = false;
+    state.handlers = handlers;
+    state.attachGeneration += 1;
+    const generation = state.attachGeneration;
+
+    if (state.socket && !state.socket.destroyed) {
+      state.socket.destroy();
+    }
+    state.socket = undefined;
+    state.hostConnected = false;
+
+    if (state.child && !state.childListenersAttached) {
+      state.childListenersAttached = true;
+      state.child.stderr?.on("data", (chunk: Buffer | string) => {
+        const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+        state.handlers?.onStderr?.(text);
+      });
+
+      state.child.on("exit", (code) => {
+        this.refreshReconnectInfo(state);
+        if (
+          !state.explicitClose &&
+          isRuntimeSessionPid(state.reconnectInfo.pid) &&
+          isRuntimeSessionPidAlive(state.reconnectInfo.pid)
+        ) {
+          return;
+        }
+        if (state.socket && !state.socket.destroyed) {
+          state.socket.destroy();
+        }
+        state.socket = undefined;
+        state.hostConnected = false;
+        this.resolvePendingParseRequests(state, 1);
+        this.cleanupSessionBootstrapFile(state);
+        state.handlers?.onExit?.(code ?? 0);
+      });
+
+      state.child.on("error", (error) => {
+        if (state.socket && !state.socket.destroyed) {
+          state.socket.destroy();
+        }
+        state.socket = undefined;
+        state.hostConnected = false;
+        this.resolvePendingParseRequests(state, 1);
+        this.cleanupSessionBootstrapFile(state);
+        state.handlers?.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+    }
+
+    void this.attachSocket(state, generation);
+  }
+
+  canUseSessionCommands(session: RuntimeSessionHandle | null): boolean {
+    if (!session) {
       return false;
     }
-    const state = this.processStates.get(process);
+    const state = this.sessionStates.get(session);
     if (!state) {
       return false;
     }
     return (
       state.hostConnected &&
-      state.capabilities.has("session-control") &&
-      state.capabilities.has("top-level-submit") &&
-      state.capabilities.has("nested-input")
+      state.capabilities.has("session-control")
     );
   }
 
-  hasCapability(process: ChildProcess | null, capability: BackendCapability): boolean {
-    if (!process) {
+  hasCapability(session: RuntimeSessionHandle | null, capability: BackendCapability): boolean {
+    if (!session) {
       return false;
     }
-    const state = this.processStates.get(process);
+    const state = this.sessionStates.get(session);
     if (!state || !state.hostConnected) {
       return false;
     }
     return state.capabilities.has(capability);
   }
 
-  sendSessionCommand(process: ChildProcess | null, command: RuntimeSessionCommand): boolean {
-    if (!process) {
+  sendSessionCommand(session: RuntimeSessionHandle | null, command: RuntimeSessionCommand): boolean {
+    if (!session) {
       return false;
     }
-    const state = this.processStates.get(process);
+    const state = this.sessionStates.get(session);
     if (!state || !state.hostConnected || !state.capabilities.has("session-control")) {
       return false;
     }
@@ -244,31 +271,31 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
         if (!state.capabilities.has("top-level-submit")) {
           return false;
         }
-        return this.writeFrame(process, encodeSubmitFrame(command.code));
+        return this.writeFrame(state, encodeSubmitFrame(command.code));
       case "interrupt":
-        return this.writeFrame(process, encodeInterruptFrame());
+        return this.writeFrame(state, encodeInterruptFrame());
       case "reply-input":
         if (!state.capabilities.has("nested-input")) {
           return false;
         }
-        return this.writeFrame(process, encodeReplyInputFrame(command.text));
+        return this.writeFrame(state, encodeReplyInputFrame(command.text));
       case "set-width":
         if (!state.capabilities.has("set-width")) {
           return false;
         }
-        return this.writeFrame(process, encodeSetWidthFrame(command.columns));
+        return this.writeFrame(state, encodeSetWidthFrame(command.columns));
       case "dialog-result":
-        return this.writeFrame(process, encodeDialogResultFrame(command.result));
+        return this.writeFrame(state, encodeDialogResultFrame(command.result));
       default:
         return false;
     }
   }
 
-  requestParseStatus(process: ChildProcess | null, code: string): Promise<number> | undefined {
-    if (!process) {
+  requestParseStatus(session: RuntimeSessionHandle | null, code: string): Promise<number> | undefined {
+    if (!session) {
       return undefined;
     }
-    const state = this.processStates.get(process);
+    const state = this.sessionStates.get(session);
     if (!state || !state.hostConnected || !state.capabilities.has("parse-status")) {
       return undefined;
     }
@@ -304,7 +331,7 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
         },
         timeout,
       });
-      const sent = this.writeFrame(process, encodeParseStatusRequestFrame(requestId, code));
+      const sent = this.writeFrame(state, encodeParseStatusRequestFrame(requestId, code));
       if (sent) {
         return;
       }
@@ -319,69 +346,311 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
     });
   }
 
-  close(process: ChildProcess): void {
-    if (!this.writeFrame(process, encodeShutdownFrame(), true)) {
+  close(session: RuntimeSessionHandle): void {
+    const state = this.sessionStates.get(session);
+    if (!state) {
       return;
     }
-    if (!process.stdin || process.killed || process.stdin.destroyed || process.stdin.writableEnded) {
+    state.explicitClose = true;
+    const shutdownSent = this.writeFrame(state, encodeShutdownFrame(), true);
+    if (shutdownSent) {
       return;
     }
-    try {
-      process.stdin.end();
-    } catch {
+    const reconnectInfo = this.readReconnectInfoFromBootstrapFile(state) ?? state.reconnectInfo;
+    if (
+      typeof reconnectInfo.port === "number" &&
+      Number.isFinite(reconnectInfo.port) &&
+      reconnectInfo.port > 0
+    ) {
+      void this.shutdownDetachedSession(state);
+      return;
     }
-  }
-
-  private writeFrame(process: ChildProcess, frame: Buffer, closing: boolean = false): boolean {
-    const state = this.processStates.get(process);
-    if (state?.commandSocket && !state.commandSocket.destroyed) {
+    if (state.child && state.child.exitCode === null && state.child.signalCode === null) {
       try {
-        state.commandSocket.write(frame);
-        if (closing) {
-          state.commandSocket.end();
-        }
-        return true;
+        state.child.kill();
       } catch {
       }
     }
-    if (state?.commandServer && globalThis.process.platform === "win32") {
-      state.pendingCommandFrames.push(Buffer.from(frame));
-      return true;
+  }
+
+  isAlive(session: RuntimeSessionHandle | null): boolean {
+    if (!session) {
+      return false;
     }
+    const state = this.sessionStates.get(session);
+    if (!state || state.explicitClose) {
+      return false;
+    }
+    this.refreshReconnectInfo(state);
+    if (isRuntimeSessionPid(state.reconnectInfo.pid)) {
+      return isRuntimeSessionPidAlive(state.reconnectInfo.pid);
+    }
+    if (state.child) {
+      return (
+        state.child.exitCode === null &&
+        state.child.signalCode === null &&
+        isRuntimeSessionPidAlive(state.child.pid)
+      );
+    }
+    return Boolean(state.socket && !state.socket.destroyed) || state.attachGeneration > 0;
+  }
+
+  getPid(session: RuntimeSessionHandle | null): number | undefined {
+    if (!session) {
+      return undefined;
+    }
+    const state = this.sessionStates.get(session);
+    if (!state) {
+      return undefined;
+    }
+    this.refreshReconnectInfo(state);
+    return state.reconnectInfo.pid ?? state.child?.pid;
+  }
+
+  getReconnectInfo(session: RuntimeSessionHandle | null): RuntimeSessionReconnectInfo | undefined {
+    if (!session) {
+      return undefined;
+    }
+    const state = this.sessionStates.get(session);
+    if (!state) {
+      return undefined;
+    }
+    this.refreshReconnectInfo(state);
+    const { sessionId, port, pid } = state.reconnectInfo;
+    if (typeof port !== "number" || !Number.isFinite(port) || port <= 0) {
+      return undefined;
+    }
+    if (isRuntimeSessionPid(pid) && !isRuntimeSessionPidAlive(pid)) {
+      cleanupRuntimeSessionBootstrapFile(sessionId);
+      return undefined;
+    }
+    return {
+      sessionId,
+      port,
+      pid,
+    };
+  }
+
+  private async attachSocket(
+    state: BackendSessionState,
+    generation: number
+  ): Promise<void> {
+    try {
+      const info = await this.resolveReconnectInfo(state);
+      if (state.attachGeneration !== generation || state.explicitClose) {
+        return;
+      }
+
+      state.reconnectInfo = { ...state.reconnectInfo, ...info };
+
+      const socket = await this.connectSocketWithRetry(state, info, generation);
+      if (state.attachGeneration !== generation || state.explicitClose) {
+        socket.destroy();
+        return;
+      }
+
+      state.socket = socket;
+      state.socketCarry = Buffer.alloc(0);
+
+      socket.on("data", (chunk: Buffer) => {
+        const parsed = parseBackendFrames(chunk, state.socketCarry);
+        state.socketCarry = parsed.carry;
+
+        if (parsed.error) {
+          state.handlers?.onError?.(new Error(parsed.error));
+          return;
+        }
+
+        for (const outputChunk of parsed.output) {
+          if (outputChunk.data.length === 0) {
+            continue;
+          }
+
+          const text = outputChunk.data.toString("utf8");
+          if (outputChunk.stream === "stderr") {
+            state.handlers?.onStderr?.(text);
+          } else {
+            state.handlers?.onStdout?.(text);
+          }
+        }
+
+        for (const event of parsed.events) {
+          this.handleSessionControlEvent(state, event);
+          state.handlers?.onControl?.(event);
+        }
+      });
+
+      socket.on("error", (error) => {
+        if (state.socket !== socket) {
+          return;
+        }
+        this.resolvePendingParseRequests(state, 1);
+        state.handlers?.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+
+      socket.on("close", () => {
+        if (state.socket !== socket) {
+          return;
+        }
+        state.socket = undefined;
+        state.hostConnected = false;
+        this.resolvePendingParseRequests(state, 1);
+        if (!state.explicitClose && !state.child) {
+          state.handlers?.onExit?.(0);
+        }
+      });
+    } catch (error) {
+      if (state.attachGeneration !== generation || state.explicitClose) {
+        return;
+      }
+      state.handlers?.onError?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private async resolveReconnectInfo(
+    state: BackendSessionState
+  ): Promise<RuntimeSessionReconnectInfo> {
+    const reconnectInfo = state.reconnectInfo;
     if (
-      !process.stdin ||
-      process.killed ||
-      process.stdin.destroyed ||
-      process.stdin.writableEnded
+      typeof reconnectInfo.port === "number" &&
+      Number.isFinite(reconnectInfo.port) &&
+      reconnectInfo.port > 0
     ) {
+      return reconnectInfo as RuntimeSessionReconnectInfo;
+    }
+
+    if (!state.sessionFilePath) {
+      throw new Error("backend session bootstrap file is unavailable");
+    }
+
+    const deadline = Date.now() + SESSION_BOOTSTRAP_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      try {
+        const raw = await fs.promises.readFile(state.sessionFilePath, "utf8");
+        const parsed = JSON.parse(raw) as SessionBootstrapFile;
+        if (
+          typeof parsed.port === "number" &&
+          Number.isFinite(parsed.port) &&
+          parsed.port > 0
+        ) {
+          return {
+            sessionId: reconnectInfo.sessionId,
+            port: parsed.port,
+            pid:
+              typeof parsed.pid === "number" && Number.isFinite(parsed.pid) && parsed.pid > 0
+                ? parsed.pid
+                : undefined,
+          };
+        }
+      } catch {
+      }
+      await new Promise((resolve) => setTimeout(resolve, SESSION_BOOTSTRAP_POLL_MS));
+    }
+
+    throw new Error(
+      `Timed out waiting for backend session bootstrap at ${state.sessionFilePath}`
+    );
+  }
+
+  private connectSocket(port: number): Promise<net.Socket> {
+    return new Promise((resolve, reject) => {
+      const socket = net.createConnection({
+        host: "127.0.0.1",
+        port,
+      });
+      const onError = (error: Error) => {
+        socket.off("connect", onConnect);
+        socket.destroy();
+        reject(error instanceof Error ? error : new Error(String(error)));
+      };
+      const onConnect = () => {
+        socket.off("error", onError);
+        resolve(socket);
+      };
+      socket.once("error", onError);
+      socket.once("connect", onConnect);
+    });
+  }
+
+  private async connectSocketWithRetry(
+    state: BackendSessionState,
+    info: RuntimeSessionReconnectInfo,
+    generation: number
+  ): Promise<net.Socket> {
+    while (true) {
+      if (state.attachGeneration !== generation || state.explicitClose) {
+        throw new Error("backend reconnect was cancelled");
+      }
+
+      // On Windows, the spawned child may be only a launcher. It exits after
+      // the real detached host writes the bootstrap file, so a child exit is
+      // not fatal while that bootstrapped host pid is alive.
+      const liveDetachedPid =
+        isRuntimeSessionPid(info.pid) &&
+        info.pid !== state.child?.pid &&
+        isRuntimeSessionPidAlive(info.pid);
+
+      if (state.child && state.child.exitCode !== null && !liveDetachedPid) {
+        throw new Error(`R backend exited with code ${state.child.exitCode}`);
+      }
+      if (state.child && state.child.signalCode !== null && !liveDetachedPid) {
+        throw new Error(`R backend exited with signal ${state.child.signalCode}`);
+      }
+      if (state.child && !liveDetachedPid && !isRuntimeSessionPidAlive(state.child.pid)) {
+        this.cleanupSessionBootstrapFile(state);
+        throw new Error(`R backend process ${state.child.pid} is no longer running`);
+      }
+      if (!state.child && isRuntimeSessionPid(info.pid) && !isRuntimeSessionPidAlive(info.pid)) {
+        cleanupRuntimeSessionBootstrapFile(info.sessionId);
+        throw new Error(`R backend process ${info.pid} is no longer running`);
+      }
+
+      try {
+        return await this.connectSocket(info.port);
+      } catch {
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, RECONNECT_SOCKET_RETRY_MS));
+    }
+  }
+
+  private writeFrame(state: BackendSessionState, frame: Buffer, closing: boolean = false): boolean {
+    if (!state.socket || state.socket.destroyed) {
       return false;
     }
     try {
-      process.stdin.write(frame);
+      state.socket.write(frame);
+      if (closing) {
+        state.socket.end();
+      }
       return true;
     } catch {
       return false;
     }
   }
 
-  private getOrCreateState(process: ChildProcess): BackendProcessState {
-    const existing = this.processStates.get(process);
+  private getOrCreateState(session: RuntimeSessionHandle): BackendSessionState {
+    const existing = this.sessionStates.get(session);
     if (existing) {
       return existing;
     }
-    const created: BackendProcessState = {
+    const created: BackendSessionState = {
       capabilities: new Set<BackendCapability>(),
       hostConnected: false,
-      pendingCommandFrames: [],
       nextRequestId: 0,
       pendingParseRequests: new Map(),
+      childListenersAttached: false,
+      reconnectInfo: { sessionId: session.sessionId },
+      socketCarry: Buffer.alloc(0),
+      explicitClose: false,
+      attachGeneration: 0,
     };
-    this.processStates.set(process, created);
+    this.sessionStates.set(session, created);
     return created;
   }
 
-  private handleProcessControlEvent(
-    state: BackendProcessState,
+  private handleSessionControlEvent(
+    state: BackendSessionState,
     event: BackendControlEvent
   ): void {
     switch (event.type) {
@@ -392,6 +661,11 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
         state.hostConnected = true;
         for (const capability of event.capabilities) {
           state.capabilities.add(capability);
+        }
+        return;
+      case "session-state":
+        if (typeof event.pid === "number" && Number.isFinite(event.pid) && event.pid > 0) {
+          state.reconnectInfo.pid = event.pid;
         }
         return;
       case "parse-status-result": {
@@ -409,18 +683,88 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
     }
   }
 
-  private resolvePendingParseRequests(state: BackendProcessState, status: number): void {
+  private resolvePendingParseRequests(state: BackendSessionState, status: number): void {
     for (const pending of state.pendingParseRequests.values()) {
       clearTimeout(pending.timeout);
       pending.resolve(status);
     }
     state.pendingParseRequests.clear();
   }
+
+  private cleanupSessionBootstrapFile(state: BackendSessionState): void {
+    if (!state.sessionFilePath) {
+      return;
+    }
+    void fs.promises.rm(state.sessionFilePath, { force: true }).catch(() => {});
+  }
+
+  private refreshReconnectInfo(state: BackendSessionState): void {
+    const resolvedInfo = this.readReconnectInfoFromBootstrapFile(state);
+    if (!resolvedInfo) {
+      return;
+    }
+    state.reconnectInfo = {
+      ...state.reconnectInfo,
+      ...resolvedInfo,
+    };
+  }
+
+  private async shutdownDetachedSession(state: BackendSessionState): Promise<void> {
+    const reconnectInfo = this.readReconnectInfoFromBootstrapFile(state) ?? state.reconnectInfo;
+    const port = reconnectInfo.port;
+    if (typeof port !== "number" || !Number.isFinite(port) || port <= 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const socket = net.createConnection(
+        {
+          host: "127.0.0.1",
+          port,
+        },
+        () => {
+          socket.end(encodeShutdownFrame());
+        }
+      );
+      const done = () => resolve();
+      socket.once("error", done);
+      socket.once("close", done);
+    });
+  }
+
+  private readReconnectInfoFromBootstrapFile(
+    state: BackendSessionState
+  ): Partial<RuntimeSessionReconnectInfo> | undefined {
+    if (!state.sessionFilePath) {
+      return undefined;
+    }
+    try {
+      const raw = fs.readFileSync(state.sessionFilePath, "utf8");
+      const parsed = JSON.parse(raw) as SessionBootstrapFile;
+      const resolved: Partial<RuntimeSessionReconnectInfo> = {};
+      if (
+        typeof parsed.port === "number" &&
+        Number.isFinite(parsed.port) &&
+        parsed.port > 0
+      ) {
+        resolved.port = parsed.port;
+      }
+      if (
+        typeof parsed.pid === "number" &&
+        Number.isFinite(parsed.pid) &&
+        parsed.pid > 0
+      ) {
+        resolved.pid = parsed.pid;
+      }
+      return Object.keys(resolved).length > 0 ? resolved : undefined;
+    } catch {
+      return undefined;
+    }
+  }
 }
 
-function createBackendCommandPipePath(): string {
-  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  return `\\\\.\\pipe\\r-console-backend-${token}`;
+function getSessionBootstrapFilePath(sessionId: string): string {
+  return path.join(os.tmpdir(), `r-console-session-${sessionId}.json`);
 }
 
 function getRustSidecarExecutableName(): string {
@@ -435,4 +779,27 @@ export function getBundledRustSidecarPath(extensionPath: string): string {
 export function resolveRustSidecarPath(extensionPath: string): string | undefined {
   const bundledPath = getBundledRustSidecarPath(extensionPath);
   return fs.existsSync(bundledPath) ? bundledPath : undefined;
+}
+
+function isRuntimeSessionPid(pid: number | undefined): pid is number {
+  return typeof pid === "number" && Number.isFinite(pid) && pid > 0;
+}
+
+function isRuntimeSessionPidAlive(pid: number | undefined): boolean {
+  if (!isRuntimeSessionPid(pid)) {
+    return true;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function cleanupRuntimeSessionBootstrapFile(sessionId: string): void {
+  try {
+    fs.rmSync(getSessionBootstrapFilePath(sessionId), { force: true });
+  } catch {
+  }
 }

--- a/src/Terminal/rTerminal.ts
+++ b/src/Terminal/rTerminal.ts
@@ -158,6 +158,7 @@ export class RTerminal implements vscode.Pseudoterminal {
   private awaitingExecutionStart = false;
   private pendingInputFlushTimer: NodeJS.Timeout | null = null;
   private pendingProgrammaticInput = "";
+  private pendingConsoleInputLines: string[] = [];
   private runtimeHostAdapter!: RuntimeHost;
 
   private programmaticSubmissionQueue: Promise<void> = Promise.resolve();
@@ -447,6 +448,8 @@ export class RTerminal implements vscode.Pseudoterminal {
       clearPendingInputFlushTimer: () => self.clearPendingInputFlushTimer(),
       clearPromptRenderTimer: () => self.clearPromptRenderTimer(),
       clearReplyPromptRenderTimer: () => self.clearReplyPromptRenderTimer(),
+      clearPendingConsoleInput: () => self.clearPendingConsoleInput(),
+      sendPendingConsoleInput: (kind) => self.sendPendingConsoleInput(kind),
       schedulePrompt: () => self.schedulePrompt(),
       scheduleReplyPrompt: () => self.scheduleReplyPrompt(),
       clearInputRender: () => self.clearInputRender(),
@@ -609,6 +612,10 @@ export class RTerminal implements vscode.Pseudoterminal {
       this.queueProgrammaticSubmission(data);
       return;
     }
+    if (this.shouldHandleAsNestedProgrammaticReply(data)) {
+      this.sendNestedReplyInput(`${this.inputState.text}${data}`);
+      return;
+    }
     if (this.mode === "executing" && this.isSessionProtocolActive()) {
       const hasCtrlC =
         data.includes("\x03") ||
@@ -671,6 +678,20 @@ export class RTerminal implements vscode.Pseudoterminal {
     );
   }
 
+  private shouldHandleAsNestedProgrammaticReply(data: string): boolean {
+    if (this.inBracketPaste || this.mode !== "reply" || !this.inputState.isAtEnd) {
+      return false;
+    }
+
+    const normalized = this.normalizeProgrammaticInput(data);
+    const fullReplyText = this.stripFinalInputNewline(`${this.inputState.text}${normalized}`);
+    return (
+      fullReplyText.includes("\n") &&
+      !normalized.includes("\x1b") &&
+      !normalized.includes("\x03")
+    );
+  }
+
   private shouldBufferProgrammaticInput(data: string): boolean {
     if (!this.canAcceptProgrammaticSubmission()) {
       return false;
@@ -692,6 +713,12 @@ export class RTerminal implements vscode.Pseudoterminal {
 
   private normalizeProgrammaticInput(data: string): string {
     return data.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  }
+
+  private stripFinalInputNewline(data: string): string {
+    // The final newline is the Enter that submits the current reply; only
+    // earlier newlines represent additional queued prompt replies.
+    return data.endsWith("\n") ? data.slice(0, -1) : data;
   }
 
   private isPlainTextInputChunk(data: string): boolean {
@@ -823,6 +850,73 @@ export class RTerminal implements vscode.Pseudoterminal {
       this.inputState.insertText(trimmed);
       this.renderInput();
     }
+  }
+
+  private handleNestedReplyPaste(content: string): boolean {
+    const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    if (!normalized.includes("\n") || !this.inputState.isAtEnd) {
+      this.inputState.insertText(normalized);
+      this.renderInput();
+      return false;
+    }
+
+    this.sendNestedReplyInput(`${this.inputState.text}${normalized}`);
+    return true;
+  }
+
+  private sendNestedReplyInput(text: string): void {
+    const normalized = this.stripFinalInputNewline(
+      stripBracketedPasteMarkers(text)
+        .replace(/\r\n/g, "\n")
+        .replace(/\r/g, "\n")
+    );
+    const lines = normalized.split("\n");
+    const firstLine = lines.shift() ?? "";
+    this.pendingConsoleInputLines.push(...lines);
+
+    this.sendNestedReplyLine(firstLine);
+  }
+
+  private clearPendingConsoleInput(): void {
+    this.pendingConsoleInputLines = [];
+  }
+
+  private sendPendingConsoleInput(kind: "top-level" | "nested"): boolean {
+    if (this.mode === "closed") {
+      return false;
+    }
+
+    const line = this.pendingConsoleInputLines.shift();
+    if (line === undefined) {
+      return false;
+    }
+
+    if (kind === "nested") {
+      this.sendNestedReplyLine(line);
+      return true;
+    }
+
+    void this.enqueueRSubmission(line, true).then((blocks) => {
+      this.recordSubmissionHistory(blocks);
+    });
+    return true;
+  }
+
+  private sendNestedReplyLine(line: string): void {
+    this.historyBrowsing = false;
+    this.historyCollapsed = true;
+    this.escPendingClear = false;
+    this.rHistory.resetIndex();
+    this.inputState.text = line;
+    this.inputState.cursorToEnd();
+
+    if (this.promptVisible) {
+      this.renderInput();
+    } else {
+      this.showReplyPrompt();
+    }
+
+    this.sendReadlineReply(line);
   }
 
   private applyKeyAction(action: KeyAction): void {
@@ -1239,6 +1333,11 @@ export class RTerminal implements vscode.Pseudoterminal {
         this.inBracketPaste = false;
         if (this.pasteBuffer.length > 0) {
           const content = stripBracketedPasteMarkers(this.pasteBuffer);
+          if (this.shouldSuppressEnterAfterPasteEnd(content)) {
+            this.suppressNextEnterAfterPasteEnd = this.handleNestedReplyPaste(content);
+            this.pasteBuffer = "";
+            return;
+          }
           this.inputState.insertText(content);
           this.pasteBuffer = "";
           this.renderInput();
@@ -2198,6 +2297,7 @@ export class RTerminal implements vscode.Pseudoterminal {
     this.lang.cleanupCompletionDocument();
     this.clearPendingInputFlushTimer();
     this.pendingProgrammaticInput = "";
+    this.clearPendingConsoleInput();
     this.clearPromptRenderTimer();
     this.clearReplyPromptRenderTimer();
 

--- a/src/Terminal/rTerminal.ts
+++ b/src/Terminal/rTerminal.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Terminal as HeadlessTerminal, type IBufferCell, type IBufferLine } from "@xterm/headless";
-import { spawnSync, ChildProcess } from "child_process";
+import { spawnSync } from "child_process";
 import * as path from "path";
 import * as os from "os";
 import { CompletionPickItem } from "../Language/completion";
@@ -22,8 +22,10 @@ import {
 } from "./options";
 import {
   RuntimeBackend,
+  type RuntimeSessionHandle,
+  type RuntimeSessionReconnectInfo,
 } from "../Runtime/runtimeBackend";
-import { SessionWatcher, WorkspaceData } from "../Runtime/sessionWatcher";
+import { SessionWatcher, type WorkspaceData } from "../Runtime/sessionWatcher";
 import {
   InputSnapshot,
   RTermLang,
@@ -43,6 +45,9 @@ import {
   finishRuntimeSubmission,
   getRuntimeTerminalName,
   interruptRuntime,
+  attachRuntimeSession,
+  primeRuntimeAttach,
+  updateRuntimeTerminalName,
   type RuntimeHost,
   startNextRuntimeSubmission,
   type Submission,
@@ -94,6 +99,42 @@ type SerializedCellStyle = {
   overline: boolean;
 };
 
+type PersistedReplaySnapshot = {
+  lines: string[];
+  finalRow: number;
+  cursorRow: number;
+  cursorCol: number;
+};
+
+type PersistedUiSnapshot = {
+  replay: PersistedReplaySnapshot;
+  replayColumns: number;
+  replayRows: number;
+  mode: TerminalMode;
+  promptReady: boolean;
+  promptKind: "main" | "cont";
+  promptVisible: boolean;
+  replyPromptText: string;
+  pendingPromptToken: boolean;
+  pendingInitialPromptGap: boolean;
+  lastWriteEndedWithNewline: boolean;
+  hasReceivedOutput: boolean;
+  inputText: string;
+  inputCursorPosition: number;
+  backendChildPid?: number;
+};
+
+export type PersistedRTerminalOptions = Pick<
+  RTerminalOptions,
+  "rPath" | "rArgs" | "sessionWatcherEnabled" | "watcherDir" | "bracketedPaste" | "cwd"
+>;
+
+export type PersistedRTerminalState = {
+  options: PersistedRTerminalOptions;
+  runtime: RuntimeSessionReconnectInfo;
+  ui: PersistedUiSnapshot;
+};
+
 export class RTerminal implements vscode.Pseudoterminal {
   private writeEmitter: vscode.EventEmitter<string>;
   private closeEmitter = new vscode.EventEmitter<number>();
@@ -114,7 +155,7 @@ export class RTerminal implements vscode.Pseudoterminal {
     return this.pidEmitter.event;
   }
 
-  private rProcess: ChildProcess | null = null;
+  private rProcess: RuntimeSessionHandle | null = null;
   private backendChildPid: number | undefined;
   private dimensions: { columns: number; rows: number } = { columns: 80, rows: 24 };
 
@@ -143,7 +184,6 @@ export class RTerminal implements vscode.Pseudoterminal {
   private pendingPromptToken = false;
   private lastWriteEndedWithNewline = true;
   private hasReceivedOutput = false;
-  private promptBlockStartRow = 0;
   private replayStartAbsoluteRow = 0;
   private terminalState: ReplayTerminal;
   private suppressTerminalStateCapture = false;
@@ -166,6 +206,7 @@ export class RTerminal implements vscode.Pseudoterminal {
 
   private submissionQueue: Submission[] = [];
   private activeSubmission: Submission | null = null;
+  private extensionResourcesDisposed = false;
 
   private inBracketPaste = false;
   private pasteBuffer = "";
@@ -174,7 +215,24 @@ export class RTerminal implements vscode.Pseudoterminal {
   private tabSize = 2;
   private lastSearchTerm = "";
 
-  constructor(private options: RTerminalOptions, private extensionPath: string = "") {
+  constructor(
+    private options: RTerminalOptions,
+    private extensionPath: string = "",
+    restoreState?: PersistedRTerminalState
+  ) {
+    if (
+      typeof restoreState?.ui.replayColumns === "number" &&
+      Number.isFinite(restoreState.ui.replayColumns) &&
+      restoreState.ui.replayColumns > 0 &&
+      typeof restoreState.ui.replayRows === "number" &&
+      Number.isFinite(restoreState.ui.replayRows) &&
+      restoreState.ui.replayRows > 0
+    ) {
+      this.dimensions = {
+        columns: Math.max(20, restoreState.ui.replayColumns),
+        rows: Math.max(5, restoreState.ui.replayRows),
+      };
+    }
     this.terminalState = this.createReplayTerminal();
     this.writeEmitter = this.createWriteEmitter();
     this.runtimeBackend = this.resolveRuntimeBackend();
@@ -206,6 +264,14 @@ export class RTerminal implements vscode.Pseudoterminal {
 
     this.loadSettings();
     this.runtimeHostAdapter = this.createRuntimeHost();
+
+    if (restoreState?.runtime && this.runtimeBackend) {
+      this.applyPersistedUiSnapshot(restoreState.ui);
+      this.rProcess = this.runtimeBackend.reconnect(restoreState.runtime);
+      primeRuntimeAttach(this.runtimeHost());
+      attachRuntimeSession(this.runtimeHost(), true);
+      updateRuntimeTerminalName(this.runtimeHost());
+    }
   }
 
   private createWriteEmitter(): vscode.EventEmitter<string> {
@@ -243,6 +309,45 @@ export class RTerminal implements vscode.Pseudoterminal {
       Math.max(20, this.dimensions.columns || 80),
       Math.max(5, this.dimensions.rows || 24)
     );
+  }
+
+  private applyPersistedUiSnapshot(snapshot: PersistedUiSnapshot): void {
+    this.mode = snapshot.mode;
+    this.promptReady = snapshot.promptReady;
+    this.promptKind = snapshot.promptKind;
+    this.promptVisible = snapshot.promptVisible;
+    this.replyPromptText = snapshot.replyPromptText;
+    this.pendingPromptToken = snapshot.pendingPromptToken;
+    this.pendingInitialPromptGap = snapshot.pendingInitialPromptGap;
+    this.lastWriteEndedWithNewline = snapshot.lastWriteEndedWithNewline;
+    this.hasReceivedOutput = snapshot.hasReceivedOutput;
+    this.backendChildPid = snapshot.backendChildPid;
+    this.inputState.text = snapshot.inputText;
+    this.inputState.cursorPosition = snapshot.inputCursorPosition;
+
+    this.terminalState.dispose();
+    this.terminalState = this.createReplayTerminal();
+    this.hydrateReplayTerminal(snapshot.replay);
+  }
+
+  private hydrateReplayTerminal(snapshot: PersistedReplaySnapshot): void {
+    if (snapshot.lines.length === 0) {
+      return;
+    }
+
+    const lines = snapshot.lines.map((line) => this.trimReplayLineRight(line));
+    lines.forEach((line, index) => {
+      this.terminalState._core._writeBuffer.writeSync(line);
+      if (index < lines.length - 1) {
+        this.terminalState._core._writeBuffer.writeSync("\r\n");
+      }
+    });
+
+    const deltaUp = snapshot.finalRow - snapshot.cursorRow;
+    if (deltaUp > 0) {
+      this.terminalState._core._writeBuffer.writeSync(`\x1b[${deltaUp}A`);
+    }
+    this.terminalState._core._writeBuffer.writeSync(`\r\x1b[${snapshot.cursorCol + 1}G`);
   }
 
   private loadSettings(): void {
@@ -449,6 +554,7 @@ export class RTerminal implements vscode.Pseudoterminal {
       clearPromptRenderTimer: () => self.clearPromptRenderTimer(),
       clearReplyPromptRenderTimer: () => self.clearReplyPromptRenderTimer(),
       clearPendingConsoleInput: () => self.clearPendingConsoleInput(),
+      captureVisibleInputForReplay: () => self.captureVisibleInputForReplay(),
       sendPendingConsoleInput: (kind) => self.sendPendingConsoleInput(kind),
       schedulePrompt: () => self.schedulePrompt(),
       scheduleReplyPrompt: () => self.scheduleReplyPrompt(),
@@ -919,6 +1025,29 @@ export class RTerminal implements vscode.Pseudoterminal {
     this.sendReadlineReply(line);
   }
 
+  private captureVisibleInputForReplay(): void {
+    if (!this.promptVisible) {
+      return;
+    }
+
+    const lines = this.inputState.lines;
+    const styledLines = this.syntax.snapshotNow(lines);
+    const continuationPad = "  ";
+
+    styledLines.forEach((line, index) => {
+      if (index > 0) {
+        this.terminalState._core._writeBuffer.writeSync("\r\n");
+      }
+      const prompt =
+        index === 0
+          ? `${ANSI.reset}${this.renderer.promptColor}${this.renderer.promptText}${ANSI.reset}`
+          : this.renderer.continuationPromptText === null
+            ? continuationPad
+            : `${ANSI.reset}${this.renderer.continuationPromptColor}${this.renderer.continuationPromptText}${ANSI.reset}`;
+      this.terminalState._core._writeBuffer.writeSync(`${prompt}${line}`);
+    });
+  }
+
   private applyKeyAction(action: KeyAction): void {
     if (this.mode === "closed") {
       return;
@@ -1073,7 +1202,6 @@ export class RTerminal implements vscode.Pseudoterminal {
         this.renderer.renderedLineCount = 1;
         this.renderer.cursorRowFromTop = 0;
         if (this.promptReady) {
-          this.promptBlockStartRow = 0;
           this.renderInputFresh(this.buildCurrentInputRenderPlan());
           this.promptVisible = true;
         }
@@ -1701,7 +1829,7 @@ export class RTerminal implements vscode.Pseudoterminal {
 
     this.withTerminalStateCaptureSuppressed(() => {
       replay.lines.forEach((line, index) => {
-        this.writeEmitter.fire(line);
+        this.writeEmitter.fire(this.trimReplayLineRight(line));
         if (index < replay.lines.length - 1) {
           this.writeEmitter.fire("\r\n");
         }
@@ -1712,21 +1840,6 @@ export class RTerminal implements vscode.Pseudoterminal {
         this.writeEmitter.fire(`\x1b[${deltaUp}A`);
       }
       this.writeEmitter.fire(`\r\x1b[${replay.cursorCol + 1}G`);
-    });
-  }
-
-  private restoreVisibleTerminalState(): void {
-    const replay = this.buildVisibleTerminalReplay();
-    if (replay.lines.length === 0) {
-      return;
-    }
-
-    this.withTerminalStateCaptureSuppressed(() => {
-      replay.lines.forEach((line, index) => {
-        this.writeEmitter.fire(`\x1b[${index + 1};1H`);
-        this.writeEmitter.fire(line);
-      });
-      this.writeEmitter.fire(`\x1b[${replay.cursorRow + 1};${replay.cursorCol + 1}H`);
     });
   }
 
@@ -1800,54 +1913,10 @@ export class RTerminal implements vscode.Pseudoterminal {
       Math.floor(absoluteCursorCol / safeColumns);
 
     return {
-      lines: lines.map((line) => line.styledText),
+      lines: lines.map((line) => this.trimReplayLineRight(line.styledText)),
       finalRow,
       cursorRow,
       cursorCol: absoluteCursorCol % safeColumns,
-    };
-  }
-
-  private buildVisibleTerminalReplay(maxRows?: number): {
-    lines: string[];
-    finalRow: number;
-    cursorRow: number;
-    cursorCol: number;
-  } {
-    const buffer = this.terminalState.buffer.active;
-    const viewportStart = buffer.viewportY;
-    const visibleRows = Array.from({ length: this.dimensions.rows }, (_, index) =>
-      this.serializeReplayRow(buffer.getLine(viewportStart + index), true)
-    );
-
-    let lastContentRow = -1;
-    for (let index = visibleRows.length - 1; index >= 0; index -= 1) {
-      if (visibleRows[index]?.plainText.trimEnd().length) {
-        lastContentRow = index;
-        break;
-      }
-    }
-
-    const finalRow = Math.max(lastContentRow, buffer.cursorY);
-    if (finalRow < 0) {
-      return { lines: [], finalRow: 0, cursorRow: 0, cursorCol: 0 };
-    }
-
-    const replayLines = visibleRows.slice(0, finalRow + 1).map((row) => row.styledText);
-    const boundedRows =
-      maxRows === undefined
-        ? replayLines.length
-        : Math.max(0, Math.min(maxRows, replayLines.length));
-    const firstVisibleRow = Math.max(0, replayLines.length - boundedRows);
-    const lines = replayLines.slice(firstVisibleRow);
-
-    return {
-      lines,
-      finalRow: Math.max(0, lines.length - 1),
-      cursorRow:
-        lines.length > 0
-          ? Math.max(0, Math.min(buffer.cursorY - firstVisibleRow, lines.length - 1))
-          : 0,
-      cursorCol: buffer.cursorX,
     };
   }
 
@@ -1919,6 +1988,22 @@ export class RTerminal implements vscode.Pseudoterminal {
       styledText,
       wrapped: line.isWrapped,
     };
+  }
+
+  private trimReplayLineRight(line: string): string {
+    let body = line;
+    let suffix = "";
+
+    while (true) {
+      const match = body.match(/(?:\x1b\[[0-9;]*m)+$/);
+      if (!match) {
+        break;
+      }
+      suffix = `${match[0]}${suffix}`;
+      body = body.slice(0, -match[0].length);
+    }
+
+    return `${body.replace(/[ \t]+$/, "")}${suffix}`;
   }
 
   private serializeCellStyle(cell: IBufferCell): SerializedCellStyle {
@@ -2056,7 +2141,6 @@ export class RTerminal implements vscode.Pseudoterminal {
       this.lastWriteEndedWithNewline = true;
     }
 
-    this.promptBlockStartRow = this.getVisibleOutputCursorRow();
     this.renderInput();
     this.promptVisible = true;
     this.pendingPromptToken = false;
@@ -2076,7 +2160,6 @@ export class RTerminal implements vscode.Pseudoterminal {
       this.lastWriteEndedWithNewline = true;
     }
 
-    this.promptBlockStartRow = this.getVisibleOutputCursorRow();
     this.renderInput();
     this.promptVisible = true;
   }
@@ -2116,13 +2199,6 @@ export class RTerminal implements vscode.Pseudoterminal {
     });
   }
 
-  private getVisibleOutputCursorRow(): number {
-    return Math.max(
-      0,
-      Math.min(this.terminalState.buffer.active.cursorY, this.dimensions.rows - 1)
-    );
-  }
-
   private renderInputFresh(plan: InputRenderPlan): void {
     this.withTerminalStateCaptureSuppressed(() => {
       this.renderer.renderFreshWithCursor(
@@ -2145,8 +2221,6 @@ export class RTerminal implements vscode.Pseudoterminal {
 
       // Use the full-buffer replay which joins wrapped rows back into logical
       // lines. xterm will re-wrap them naturally at the new column width.
-      // buildVisibleTerminalReplay() returns raw rows already wrapped at the
-      // old width, which would cause double-wrapping artifacts.
       const replay = this.buildTerminalReplay();
       replay.lines.forEach((line, index) => {
         if (index > 0) {
@@ -2174,7 +2248,6 @@ export class RTerminal implements vscode.Pseudoterminal {
           plan.sourceLineMap,
           plan.promptKinds
         );
-        this.promptBlockStartRow = this.getVisibleOutputCursorRow();
         this.promptVisible = true;
       }
     });
@@ -2290,7 +2363,11 @@ export class RTerminal implements vscode.Pseudoterminal {
     this.closeEmitter.fire(0);
   }
 
-  forceClose(): void {
+  private releaseExtensionResources(): void {
+    if (this.extensionResourcesDisposed) {
+      return;
+    }
+    this.extensionResourcesDisposed = true;
     this.saveHistory();
     this.sessionWatcher?.dispose();
     this.syntax.dispose();
@@ -2305,22 +2382,23 @@ export class RTerminal implements vscode.Pseudoterminal {
     this.lang.clearSessionState();
     this.lang.stopConsoleLsp();
     setNativeParseCallback(null);
+  }
+
+  forceClose(): void {
+    this.releaseExtensionResources();
 
     if (this.rProcess) {
       const processToClose = this.rProcess;
-      const pid = processToClose.pid;
+      const pid = this.runtimeBackend?.getPid(processToClose);
       if (this.runtimeBackend) {
         this.runtimeBackend.close(processToClose);
         // Give sidecar a short grace window to terminate its PTY child cleanly.
         if (pid) {
-          const forceKillTimer = setTimeout(() => {
-            if (processToClose.exitCode === null && processToClose.signalCode === null) {
+          setTimeout(() => {
+            if (this.runtimeBackend?.isAlive(processToClose)) {
               this.killProcessTree(pid);
             }
           }, 1200);
-          processToClose.once("exit", () => {
-            clearTimeout(forceKillTimer);
-          });
         }
       } else {
         this.killProcessTree(pid);
@@ -2348,11 +2426,58 @@ export class RTerminal implements vscode.Pseudoterminal {
   }
 
   isRunning(): boolean {
-    return this.rProcess !== null && !this.rProcess.killed;
+    return this.rProcess !== null && (this.runtimeBackend?.isAlive(this.rProcess) ?? false);
+  }
+
+  requiresCloseConfirmation(): boolean {
+    return this.isRunning();
   }
 
   getPid(): number | undefined {
     return this.getDisplayPid();
+  }
+
+  getTerminalName(): string {
+    return getRuntimeTerminalName(this.runtimeHost());
+  }
+
+  exportPersistentState(): PersistedRTerminalState | undefined {
+    if (!this.runtimeBackend || !this.rProcess) {
+      return undefined;
+    }
+    const runtime = this.runtimeBackend.getReconnectInfo(this.rProcess);
+    if (!runtime) {
+      return undefined;
+    }
+
+    return {
+      options: {
+        rPath: this.options.rPath,
+        rArgs: [...this.options.rArgs],
+        sessionWatcherEnabled: this.options.sessionWatcherEnabled,
+        watcherDir: this.options.watcherDir,
+        bracketedPaste: this.options.bracketedPaste,
+        cwd: this.options.cwd,
+      },
+      runtime,
+      ui: {
+        replay: this.buildTerminalReplay(),
+        replayColumns: this.dimensions.columns,
+        replayRows: this.dimensions.rows,
+        mode: this.mode,
+        promptReady: this.promptReady,
+        promptKind: this.promptKind,
+        promptVisible: this.promptVisible,
+        replyPromptText: this.replyPromptText,
+        pendingPromptToken: this.pendingPromptToken,
+        pendingInitialPromptGap: this.pendingInitialPromptGap,
+        lastWriteEndedWithNewline: this.lastWriteEndedWithNewline,
+        hasReceivedOutput: this.hasReceivedOutput,
+        inputText: this.inputState.text,
+        inputCursorPosition: this.inputState.cursorPosition,
+        backendChildPid: this.backendChildPid,
+      },
+    };
   }
 
   private getDisplayPid(): number | undefined {
@@ -2365,7 +2490,7 @@ export class RTerminal implements vscode.Pseudoterminal {
     if (typeof this.backendChildPid === "number") {
       return this.backendChildPid;
     }
-    return this.rProcess?.pid;
+    return this.runtimeBackend?.getPid(this.rProcess);
   }
 
   notifyDisplayPidChanged(): void {
@@ -2378,7 +2503,7 @@ export class RTerminal implements vscode.Pseudoterminal {
   }
 
   dispose(): void {
-    this.forceClose();
+    this.releaseExtensionResources();
     this.writeEmitter.dispose();
     this.closeEmitter.dispose();
     this.nameEmitter.dispose();

--- a/src/Terminal/rTerminal.ts
+++ b/src/Terminal/rTerminal.ts
@@ -838,6 +838,7 @@ export class RTerminal implements vscode.Pseudoterminal {
     }
 
     if (this.mode === "reply") {
+      this.ensureReplyPromptVisibleForInput();
       this.handleReplyInputAction(action);
       return;
     }
@@ -845,6 +846,8 @@ export class RTerminal implements vscode.Pseudoterminal {
     if (this.mode !== "ready" || !this.promptReady) {
       return;
     }
+
+    this.ensureReadyPromptVisibleForInput();
 
     if (action.type !== "escape") {
       this.escPendingClear = false;
@@ -1473,6 +1476,22 @@ export class RTerminal implements vscode.Pseudoterminal {
 
   private interruptR(): void {
     interruptRuntime(this.runtimeHost());
+  }
+
+  private ensureReadyPromptVisibleForInput(): void {
+    if (this.promptVisible) {
+      return;
+    }
+    this.clearPromptRenderTimer();
+    this.showPrompt();
+  }
+
+  private ensureReplyPromptVisibleForInput(): void {
+    if (this.promptVisible) {
+      return;
+    }
+    this.clearReplyPromptRenderTimer();
+    this.showReplyPrompt();
   }
 
   private schedulePrompt(): void {

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -277,7 +277,7 @@ export function handleRuntimeControl(
   event: BackendControlEvent
 ): void {
   if (event.type !== "output-flush") {
-    flushPendingRuntimeRewrite(host);
+    discardPendingRuntimeRewrite(host);
   }
 
   switch (event.type) {
@@ -852,22 +852,14 @@ function getPendingRuntimeRewrite(host: RuntimeHost): PendingRuntimeRewrite {
   return pending;
 }
 
-function flushPendingRuntimeRewrite(host: RuntimeHost): void {
+function discardPendingRuntimeRewrite(host: RuntimeHost): void {
   const pending = pendingRuntimeRewrites.get(host);
   if (!pending) {
     return;
   }
 
-  if (pending.clearFrame) {
-    const clearFrame = pending.clearFrame;
-    pending.clearFrame = null;
-    writeRuntimeText(host, clearFrame.text, clearFrame.endedWithLineFeed);
-  }
-
-  if (pending.bareCarriageReturn) {
-    pending.bareCarriageReturn = false;
-    writeRuntimeText(host, "\r", false);
-  }
+  pending.clearFrame = null;
+  pending.bareCarriageReturn = false;
 }
 
 export function sendRuntimeReply(host: RuntimeHost, text: string): void {
@@ -1103,7 +1095,7 @@ export function handleRuntimeExit(host: RuntimeHost, code: number): void {
   host.clearPendingInputFlushTimer();
   host.clearPromptRenderTimer();
   host.clearReplyPromptRenderTimer();
-  flushPendingRuntimeRewrite(host);
+  discardPendingRuntimeRewrite(host);
   setNativeParseCallback(null);
 
   host.lang.cleanupCompletionDocument();

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -50,6 +50,7 @@ export type TerminalMode = "starting" | "ready" | "executing" | "reply" | "close
 
 export type Submission = {
   code: string;
+  initialPromptKind: "main" | "cont";
 };
 
 const pendingRuntimeRewrites = new WeakMap<RuntimeHost, PendingRuntimeRewrite>();
@@ -89,6 +90,8 @@ export type RuntimeHost = {
   clearPendingInputFlushTimer(): void;
   clearPromptRenderTimer(): void;
   clearReplyPromptRenderTimer(): void;
+  clearPendingConsoleInput(): void;
+  sendPendingConsoleInput(kind: "top-level" | "nested"): boolean;
   schedulePrompt(): void;
   scheduleReplyPrompt(): void;
   clearInputRender(): void;
@@ -138,6 +141,7 @@ export function startRuntime(host: RuntimeHost): void {
   host.clearPromptRenderTimer();
   host.lang.stopConsoleLsp();
   host.lang.clearSessionState();
+  host.clearPendingConsoleInput();
   host.pendingPromptToken = true;
   host.mode = "starting";
   host.promptReady = false;
@@ -421,6 +425,10 @@ export function handleBackendPrompt(
     return;
   }
 
+  if (host.sendPendingConsoleInput("top-level")) {
+    return;
+  }
+
   host.pendingPromptToken = true;
   host.schedulePrompt();
   if (kind === "main" && host.mode === "ready" && host.activeSubmission === null) {
@@ -454,6 +462,9 @@ export function handleBackendInputRequest(
   }
 
   host.mode = "reply";
+  if (host.sendPendingConsoleInput("nested")) {
+    return;
+  }
   host.scheduleReplyPrompt();
 }
 
@@ -934,6 +945,7 @@ export async function enqueueRuntimeSubmission(
   for (const block of blocks) {
     host.submissionQueue.push({
       code: block,
+      initialPromptKind: host.promptKind,
     });
   }
 
@@ -1014,7 +1026,11 @@ function writeRuntimeSubmissionEcho(host: RuntimeHost, task: Submission): void {
     getContinuationPromptLength(host.renderer.continuationPromptText)
   );
   const styledLines = host.syntax.highlightLines(plan.lines, plan.sourceLineMap);
-  writeRuntimeSubmissionLines(host, styledLines, plan.promptKinds);
+  const promptKinds = [...plan.promptKinds];
+  if (task.initialPromptKind === "cont" && promptKinds.length > 0) {
+    promptKinds[0] = "cont";
+  }
+  writeRuntimeSubmissionLines(host, styledLines, promptKinds);
   host.promptVisible = false;
 }
 
@@ -1060,6 +1076,7 @@ export function interruptRuntime(host: RuntimeHost): void {
     host.inputState.reset();
     host.promptVisible = false;
     host.pendingPromptToken = false;
+    host.clearPendingConsoleInput();
     return;
   }
 
@@ -1071,6 +1088,7 @@ export function interruptRuntime(host: RuntimeHost): void {
     host.promptVisible = false;
     host.replyPromptText = "";
     host.mode = "executing";
+    host.clearPendingConsoleInput();
     sendInterrupt();
     return;
   }
@@ -1079,6 +1097,7 @@ export function interruptRuntime(host: RuntimeHost): void {
     host.clearInputRender();
     host.inputState.reset();
     host.renderInput();
+    host.clearPendingConsoleInput();
     return;
   }
 
@@ -1089,12 +1108,14 @@ export function interruptRuntime(host: RuntimeHost): void {
   host.writeEmitter.fire("^C\r\n");
   host.inputState.reset();
   host.promptVisible = false;
+  host.clearPendingConsoleInput();
 }
 
 export function handleRuntimeExit(host: RuntimeHost, code: number): void {
   host.clearPendingInputFlushTimer();
   host.clearPromptRenderTimer();
   host.clearReplyPromptRenderTimer();
+  host.clearPendingConsoleInput();
   discardPendingRuntimeRewrite(host);
   setNativeParseCallback(null);
 

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -312,7 +312,7 @@ export function handleRuntimeControl(
   event: BackendControlEvent
 ): void {
   if (event.type !== "output-flush") {
-    discardPendingRuntimeRewrite(host);
+    flushPendingRuntimeRewrite(host);
   }
 
   switch (event.type) {
@@ -793,7 +793,7 @@ export function handleRuntimeError(host: RuntimeHost, error: string): void {
   const formatted = formatViewOutput(stripBracketedPasteMarkers(error));
   renderRuntimeText(
     host,
-    `${ANSI.red}${formatted}${ANSI.reset}`,
+    colorRuntimeText(formatted, ANSI.red, ANSI.reset),
     didOutputEndWithLineFeed(formatted)
   );
 }
@@ -903,7 +903,7 @@ function shouldPrefixPendingCarriageReturn(text: string): boolean {
 }
 
 function shouldDeferClearFrame(text: string): boolean {
-  return /^\r\s*\| +$/.test(text);
+  return /^\r\s*\| +$/.test(stripSgrCodes(text));
 }
 
 function shouldReplacePendingClearFrame(text: string): boolean {
@@ -911,11 +911,33 @@ function shouldReplacePendingClearFrame(text: string): boolean {
 }
 
 function isSimpleCarriageReturnRewrite(text: string): boolean {
-  return text.startsWith("\r") && !text.includes("\n") && !text.includes("\b") && !/\x1b\[/.test(text);
+  const withoutSgr = stripSgrCodes(text);
+  return (
+    withoutSgr.startsWith("\r") &&
+    !withoutSgr.includes("\n") &&
+    !withoutSgr.includes("\b") &&
+    !/\x1b/.test(withoutSgr)
+  );
 }
 
 function rewriteSimpleCarriageReturnOutput(text: string): string {
   return `\x1b[2K\x1b[1G${text.slice(1)}`;
+}
+
+function colorRuntimeText(text: string, prefix: string, suffix: string): string {
+  if (!text || text === "\r") {
+    return text;
+  }
+
+  if (text.startsWith("\r") && !text.startsWith("\r\n")) {
+    return `\r${prefix}${text.slice(1)}${suffix}`;
+  }
+
+  return `${prefix}${text}${suffix}`;
+}
+
+function stripSgrCodes(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 function didOutputEndWithLineFeed(text: string): boolean {
@@ -934,14 +956,22 @@ function getPendingRuntimeRewrite(host: RuntimeHost): PendingRuntimeRewrite {
   return pending;
 }
 
-function discardPendingRuntimeRewrite(host: RuntimeHost): void {
+function flushPendingRuntimeRewrite(host: RuntimeHost): void {
   const pending = pendingRuntimeRewrites.get(host);
   if (!pending) {
     return;
   }
 
-  pending.clearFrame = null;
-  pending.bareCarriageReturn = false;
+  if (pending.clearFrame) {
+    const clearFrame = pending.clearFrame;
+    pending.clearFrame = null;
+    writeRuntimeText(host, clearFrame.text, clearFrame.endedWithLineFeed);
+  }
+
+  if (pending.bareCarriageReturn) {
+    pending.bareCarriageReturn = false;
+    writeRuntimeText(host, "\r", false);
+  }
 }
 
 export function sendRuntimeReply(host: RuntimeHost, text: string): void {
@@ -1190,7 +1220,7 @@ export function handleRuntimeExit(host: RuntimeHost, code: number): void {
   host.clearPromptRenderTimer();
   host.clearReplyPromptRenderTimer();
   host.clearPendingConsoleInput();
-  discardPendingRuntimeRewrite(host);
+  flushPendingRuntimeRewrite(host);
   setNativeParseCallback(null);
 
   host.lang.cleanupCompletionDocument();

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -976,7 +976,19 @@ function flushPendingRuntimeRewrite(host: RuntimeHost): void {
 
 export function sendRuntimeReply(host: RuntimeHost, text: string): void {
   host.clearReplyPromptRenderTimer();
+  const sent =
+    host.runtimeBackend?.sendSessionCommand(host.rProcess, {
+      type: "reply-input",
+      text,
+    }) ?? false;
+
+  if (!sent) {
+    host.scheduleReplyPrompt();
+    return;
+  }
+
   if (host.promptVisible) {
+    host.captureVisibleInputForReplay();
     host.writeEmitter.fire("\r\n");
     host.lastWriteEndedWithNewline = true;
     host.renderer.renderedLineCount = 1;
@@ -987,10 +999,6 @@ export function sendRuntimeReply(host: RuntimeHost, text: string): void {
   host.mode = host.activeSubmission ? "executing" : "ready";
   host.awaitingExecutionStart = false;
   host.replyPromptText = "";
-  host.runtimeBackend?.sendSessionCommand(host.rProcess, {
-    type: "reply-input",
-    text,
-  });
 }
 
 export function startRuntimeSubmission(host: RuntimeHost, task: Submission): void {

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import type { ChildProcess } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { setNativeParseCallback, stripCommentLines } from "../../Language/parser";
@@ -11,6 +10,7 @@ import {
   getBundledRustSidecarPath,
   resolveRustSidecarPath,
   RuntimeBackend,
+  type RuntimeSessionHandle,
   RustSidecarRuntimeBackend,
 } from "../../Runtime/runtimeBackend";
 import type { SessionWatcher, WorkspaceData } from "../../Runtime/sessionWatcher";
@@ -59,7 +59,7 @@ export type RuntimeHost = {
   options: RTerminalOptions;
   extensionPath: string;
   runtimeBackend: RuntimeBackend | undefined;
-  rProcess: ChildProcess | null;
+  rProcess: RuntimeSessionHandle | null;
   backendChildPid: number | undefined;
   dimensions: Dimensions;
   mode: TerminalMode;
@@ -91,6 +91,7 @@ export type RuntimeHost = {
   clearPromptRenderTimer(): void;
   clearReplyPromptRenderTimer(): void;
   clearPendingConsoleInput(): void;
+  captureVisibleInputForReplay(): void;
   sendPendingConsoleInput(kind: "top-level" | "nested"): boolean;
   schedulePrompt(): void;
   scheduleReplyPrompt(): void;
@@ -171,6 +172,9 @@ export function startRuntime(host: RuntimeHost): void {
   }
 
   try {
+    if (host.options.sessionWatcherEnabled) {
+      fs.mkdirSync(host.options.watcherDir, { recursive: true });
+    }
     const args = [host.options.rPath, ...host.options.rArgs];
     const runtimeEnv: NodeJS.ProcessEnv = { ...host.options.env };
     if (host.extensionPath) {
@@ -191,37 +195,12 @@ export function startRuntime(host: RuntimeHost): void {
       cwd: host.options.cwd,
       env: runtimeEnv,
     });
+    primeRuntimeAttach(host);
     setNativeParseCallback(null);
     void host.lang.start();
-    host.runtimeBackend.attach(host.rProcess, {
-      onStdout: (output) => {
-        handleRuntimeOutput(host, output);
-      },
-      onStderr: (errorText) => {
-        handleRuntimeError(host, errorText);
-      },
-      onControl: (event) => {
-        handleRuntimeControl(host, event);
-      },
-      onExit: (code) => {
-        handleRuntimeExit(host, code);
-      },
-      onError: (err) => {
-        setNativeParseCallback(null);
-        host.writeEmitter.fire(
-          `${ANSI.red}Failed to start R: ${err.message}${ANSI.reset}\r\n`
-        );
-        host.mode = "closed";
-        host.rProcess = null;
-        host.sessionAttached = false;
-        host.lang.stopConsoleLsp();
-      },
-    });
+    attachRuntimeSession(host, true);
 
     updateRuntimeTerminalName(host);
-    if (!host.options.sessionWatcherEnabled) {
-      host.sessionAttached = true;
-    }
   } catch (err) {
     host.writeEmitter.fire(
       `${ANSI.red}Failed to start R: ${String(err)}${ANSI.reset}\r\n`
@@ -231,6 +210,58 @@ export function startRuntime(host: RuntimeHost): void {
     host.sessionAttached = false;
     host.lang.stopConsoleLsp();
   }
+}
+
+export function primeRuntimeAttach(
+  host: RuntimeHost
+): void {
+  if (!host.options.sessionWatcherEnabled || !host.sessionWatcher) {
+    return;
+  }
+
+  const runtimePid = host.runtimeBackend?.getPid(host.rProcess) ?? host.getDisplayPid();
+  if (typeof runtimePid === "number" && Number.isFinite(runtimePid) && runtimePid > 0) {
+    host.sessionWatcher.setExpectedPid(runtimePid);
+  }
+
+  beginRuntimeAttach(host);
+}
+
+export function attachRuntimeSession(host: RuntimeHost, showStartupErrors: boolean = false): void {
+  if (!host.runtimeBackend || !host.rProcess) {
+    return;
+  }
+  if (!host.options.sessionWatcherEnabled || !host.sessionWatcher) {
+    host.sessionAttached = true;
+  }
+  setNativeParseCallback(null);
+  void host.lang.start();
+  host.runtimeBackend.attach(host.rProcess, {
+    onStdout: (output) => {
+      handleRuntimeOutput(host, output);
+    },
+    onStderr: (errorText) => {
+      handleRuntimeError(host, errorText);
+    },
+    onControl: (event) => {
+      handleRuntimeControl(host, event);
+    },
+    onExit: (code) => {
+      handleRuntimeExit(host, code);
+    },
+    onError: (err) => {
+      setNativeParseCallback(null);
+      if (showStartupErrors) {
+        host.writeEmitter.fire(
+          `${ANSI.red}Failed to start R: ${err.message}${ANSI.reset}\r\n`
+        );
+      }
+      host.mode = "closed";
+      host.rProcess = null;
+      host.sessionAttached = false;
+      host.lang.stopConsoleLsp();
+    },
+  });
 }
 
 function beginRuntimeAttach(host: RuntimeHost): void {
@@ -291,18 +322,6 @@ export function handleRuntimeControl(
       host.sessionHostConnected = true;
       updateNativeParseCallback(host);
       return;
-    case "child-spawned":
-      if (typeof event.pid === "number" && Number.isFinite(event.pid) && event.pid > 0) {
-        host.backendChildPid = event.pid;
-        updateRuntimeTerminalName(host);
-        if (host.options.sessionWatcherEnabled && host.sessionWatcher) {
-          host.sessionWatcher.setExpectedPid(event.pid);
-          beginRuntimeAttach(host);
-        }
-      } else if (host.options.sessionWatcherEnabled && host.sessionWatcher) {
-        beginRuntimeAttach(host);
-      }
-      return;
     case "prompt":
       handleBackendPrompt(host, event.kind);
       return;
@@ -356,6 +375,58 @@ export function handleRuntimeControl(
           host,
           event.message.endsWith("\n") ? event.message : `${event.message}\n`
         );
+      }
+      return;
+    case "session-state":
+      applyRuntimeSessionState(host, event);
+      return;
+  }
+}
+
+function applyRuntimeSessionState(
+  host: RuntimeHost,
+  event: Extract<BackendControlEvent, { type: "session-state" }>
+): void {
+  if (typeof event.pid === "number" && Number.isFinite(event.pid) && event.pid > 0) {
+    host.backendChildPid = event.pid;
+    updateRuntimeTerminalName(host);
+    if (host.options.sessionWatcherEnabled && host.sessionWatcher) {
+      host.sessionWatcher.setExpectedPid(event.pid);
+    }
+  }
+
+  host.sessionHostConnected = true;
+  updateNativeParseCallback(host);
+
+  if (event.busy) {
+    host.promptReady = false;
+    host.promptVisible = false;
+    host.pendingPromptToken = false;
+    if (host.mode !== "closed") {
+      host.mode = "executing";
+    }
+    return;
+  }
+
+  switch (event.wait.kind) {
+    case "none":
+      return;
+    case "top-level":
+      host.promptReady = true;
+      host.promptKind = event.wait.prompt;
+      host.replyPromptText = "";
+      if (host.mode !== "closed") {
+        host.mode = "ready";
+      }
+      if (!host.promptVisible) {
+        host.pendingPromptToken = true;
+      }
+      return;
+    case "nested":
+      host.promptReady = false;
+      host.replyPromptText = event.wait.prompt;
+      if (host.mode !== "closed") {
+        host.mode = "reply";
       }
       return;
   }
@@ -1000,6 +1071,9 @@ function writeRuntimeSubmissionEcho(host: RuntimeHost, task: Submission): void {
   configureMainPrompt(host.renderer);
 
   if (host.promptVisible || host.inputState.text.length > 0) {
+    if (host.promptVisible) {
+      host.captureVisibleInputForReplay();
+    }
     host.clearInputRender();
     host.promptVisible = false;
   } else {
@@ -1061,7 +1135,7 @@ function writeRuntimeSubmissionLines(
   host.renderer.cursorRowFromTop = 0;
 }
 export function interruptRuntime(host: RuntimeHost): void {
-  if (!host.rProcess || host.rProcess.killed) {
+  if (!host.rProcess || !host.runtimeBackend?.isAlive(host.rProcess)) {
     return;
   }
 

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -1183,8 +1183,10 @@ export function interruptRuntime(host: RuntimeHost): void {
     }) ?? false;
 
   if (host.isSessionProtocolActive() && host.mode === "executing") {
+    if (!sendInterrupt()) {
+      return;
+    }
     host.writeEmitter.fire("^C\r\n");
-    sendInterrupt();
     host.inputState.reset();
     host.promptVisible = false;
     host.pendingPromptToken = false;
@@ -1193,6 +1195,10 @@ export function interruptRuntime(host: RuntimeHost): void {
   }
 
   if (host.isSessionProtocolActive() && host.mode === "reply") {
+    if (!sendInterrupt()) {
+      host.scheduleReplyPrompt();
+      return;
+    }
     host.clearReplyPromptRenderTimer();
     host.writeEmitter.fire("^C\r\n");
     host.clearInputRender();
@@ -1201,7 +1207,6 @@ export function interruptRuntime(host: RuntimeHost): void {
     host.replyPromptText = "";
     host.mode = "executing";
     host.clearPendingConsoleInput();
-    sendInterrupt();
     return;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,13 @@
 import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
 import {
   RTerminal,
+  type PersistedRTerminalState,
+  type PersistedRTerminalOptions,
   resolveRTerminalOptions,
 } from "./Terminal/rTerminal";
+import { createRuntimeBackend } from "./Terminal/rTerminal/runtime";
 import {
   discoverRBinaryPath,
   getPlatformRPathConfigEntry,
@@ -15,16 +20,53 @@ type TerminalContext =
 type ConsoleRecord = {
   rTerminal: RTerminal;
   location: TerminalContext;
+  terminal?: vscode.Terminal;
   pid?: number;
   pidSubscription: vscode.Disposable;
+};
+
+type PersistedConsoleRecord = {
+  terminal: PersistedRTerminalState;
+  location: TerminalContext;
+};
+
+type PersistentSessionState = {
+  sessions: PersistedConsoleRecord[];
+};
+
+type ManagedPersistentSession = {
+  sessionId: string;
+  entry: PersistedConsoleRecord;
+  attachedRecord?: ConsoleRecord;
+  pid?: number;
+  attached: boolean;
+};
+
+type ManageAction = vscode.QuickPickItem & {
+  action: "attach" | "attachAll" | "close" | "closeAll" | "refresh";
+};
+
+type ManagedSessionPick = vscode.QuickPickItem & {
+  session: ManagedPersistentSession;
 };
 
 const terminalToRecord: Map<vscode.Terminal, ConsoleRecord> = new Map();
 const rTerminalToRecord: Map<RTerminal, ConsoleRecord> = new Map();
 const pidToRecord: Map<number, ConsoleRecord> = new Map();
+const persistentSessionRecords: Map<string, PersistedConsoleRecord> = new Map();
 const editorCloseInProgress: Set<number> = new Set();
-const VSCODE_R_TERMINAL_NAME = "R Console";
+const ignoredEditorClosePids: Set<number> = new Set();
+const closeConfirmationInProgress = new WeakSet<ConsoleRecord>();
+const ignoredTerminalCloseEvents = new WeakSet<vscode.Terminal>();
+const R_CONSOLE_PID_LABEL_PATTERN = /^R Console \((\d+)\)$/;
+const PERSIST_DEBOUNCE_MS = 250;
+const PERSIST_HEARTBEAT_MS = 5000;
 let extensionBaseUri: vscode.Uri | undefined;
+let persistentSessionFilePath: string | undefined;
+let legacyReloadSessionFilePath: string | undefined;
+let persistDebounceTimer: NodeJS.Timeout | undefined;
+let persistHeartbeatTimer: NodeJS.Timeout | undefined;
+let extensionHostDeactivating = false;
 
 function isVirtualWorkspace(): boolean {
   const folders = vscode.workspace.workspaceFolders;
@@ -37,14 +79,35 @@ function refreshTerminalAppearance(): void {
   }
 }
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  extensionHostDeactivating = false;
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      extensionHostDeactivating = true;
+    })
+  );
   extensionBaseUri = context.extensionUri;
+  const sessionStorageUri = context.storageUri ?? context.globalStorageUri;
+  persistentSessionFilePath = vscode.Uri.joinPath(
+    sessionStorageUri,
+    "persistent-sessions.json"
+  ).fsPath;
+  legacyReloadSessionFilePath = vscode.Uri.joinPath(
+    sessionStorageUri,
+    "reload-sessions.json"
+  ).fsPath;
+  void fs.promises.mkdir(sessionStorageUri.fsPath, { recursive: true }).catch(() => {});
+  await initializePersistentSessionRegistry();
+  startPersistentSessionRegistry(context);
   context.subscriptions.push(
     vscode.commands.registerCommand("r-console.createTerminal", () => {
       void createRTerminal(context);
     }),
     vscode.commands.registerCommand("r-console.createTerminalSide", () => {
       void createRTerminal(context, true);
+    }),
+    vscode.commands.registerCommand("r-console.managePersistentSessions", () => {
+      void managePersistentSessions(context);
     }),
     vscode.window.onDidOpenTerminal(handleTerminalOpen),
     vscode.window.onDidChangeActiveTerminal(handleActiveTerminalChange),
@@ -64,15 +127,302 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  disposeStalePersistentTerminalViews();
   syncTerminalRecordsFromWindow();
   void ensureConfiguredRPath();
 }
 
+async function initializePersistentSessionRegistry(): Promise<void> {
+  persistentSessionRecords.clear();
+  const records = await loadPersistentSessionsFromDisk();
+  for (const entry of records) {
+    persistentSessionRecords.set(entry.terminal.runtime.sessionId, entry);
+  }
+  if (records.length > 0) {
+    persistPersistentSessions();
+  }
+}
+
+async function loadPersistentSessionsFromDisk(): Promise<PersistedConsoleRecord[]> {
+  const records = new Map<string, PersistedConsoleRecord>();
+
+  for (const filePath of [persistentSessionFilePath, legacyReloadSessionFilePath]) {
+    if (!filePath) {
+      continue;
+    }
+    for (const entry of await readPersistentSessionFile(filePath)) {
+      records.set(entry.terminal.runtime.sessionId, entry);
+    }
+  }
+
+  const liveRecords = [...records.values()].filter(hasLivePersistedRuntime);
+  if (liveRecords.length === 0) {
+    await removePersistentSessionFiles();
+  }
+  return liveRecords;
+}
+
+async function readPersistentSessionFile(filePath: string): Promise<PersistedConsoleRecord[]> {
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw);
+    const sessions = parsePersistentSessionState(parsed);
+    return sessions ? sessions.filter(hasLivePersistedRuntime) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function removePersistentSessionFiles(): Promise<void> {
+  await Promise.all(
+    [persistentSessionFilePath, legacyReloadSessionFilePath]
+      .filter((filePath): filePath is string => typeof filePath === "string")
+      .map((filePath) => fs.promises.rm(filePath, { force: true }).catch(() => {}))
+  );
+}
+
+function buildPersistentTerminalOptions(
+  persistedOptions: PersistedRTerminalOptions
+): ReturnType<typeof resolveRTerminalOptions> {
+  const currentOptions = resolveRTerminalOptions();
+  if (!currentOptions) {
+    return undefined;
+  }
+  return {
+    ...currentOptions,
+    ...persistedOptions,
+    rArgs: [...persistedOptions.rArgs],
+  };
+}
+
+function disposeStalePersistentTerminalViews(): void {
+  const persistentPids = new Set<number>();
+  for (const entry of persistentSessionRecords.values()) {
+    const pid = getPersistedRuntimePid(entry.terminal);
+    if (typeof pid === "number") {
+      persistentPids.add(pid);
+    }
+  }
+  if (persistentPids.size === 0) {
+    return;
+  }
+
+  const ignoredPids = new Set<number>();
+  for (const terminal of vscode.window.terminals) {
+    if (resolveRecordFromTerminal(terminal)) {
+      continue;
+    }
+    const pid = parseConsolePidFromTerminal(terminal);
+    if (typeof pid !== "number" || !persistentPids.has(pid)) {
+      continue;
+    }
+    ignoredTerminalCloseEvents.add(terminal);
+    ignoredEditorClosePids.add(pid);
+    ignoredPids.add(pid);
+    terminal.dispose();
+  }
+
+  if (ignoredPids.size > 0) {
+    setTimeout(() => {
+      for (const pid of ignoredPids) {
+        ignoredEditorClosePids.delete(pid);
+      }
+    }, 1000);
+  }
+}
+
+function getPersistedRuntimePid(state: PersistedRTerminalState): number | undefined {
+  const runtimePid = state.runtime.pid;
+  if (isPositiveInteger(runtimePid)) {
+    return runtimePid;
+  }
+
+  const backendChildPid = state.ui.backendChildPid;
+  return isPositiveInteger(backendChildPid) ? backendChildPid : undefined;
+}
+
+function hasLivePersistedRuntime(entry: PersistedConsoleRecord): boolean {
+  const pid = getPersistedRuntimePid(entry.terminal);
+  return typeof pid !== "number" || isProcessAlive(pid);
+}
+
+function isPersistedConsoleRecord(value: unknown): value is PersistedConsoleRecord {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (!isPersistedRTerminalState(value.terminal)) {
+    return false;
+  }
+  if (!isPersistedTerminalContext(value.location)) {
+    return false;
+  }
+  return true;
+}
+
+function parsePersistentSessionState(value: unknown): PersistedConsoleRecord[] | undefined {
+  if (!isObjectRecord(value)) {
+    return undefined;
+  }
+  const sessions =
+    Array.isArray(value.sessions)
+      ? value.sessions
+      : Array.isArray(value.consoles)
+        ? value.consoles
+        : undefined;
+  if (!sessions || !sessions.every(isPersistedConsoleRecord)) {
+    return undefined;
+  }
+  return sessions;
+}
+
+function isPersistedRTerminalState(value: unknown): value is PersistedRTerminalState {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  return (
+    isPersistedRTerminalOptions(value.options) &&
+    isRuntimeSessionReconnectInfo(value.runtime) &&
+    isPersistedUiSnapshot(value.ui)
+  );
+}
+
+function isPersistedRTerminalOptions(value: unknown): value is PersistedRTerminalOptions {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (typeof value.rPath !== "string" || value.rPath.trim().length === 0) {
+    return false;
+  }
+  if (!Array.isArray(value.rArgs) || value.rArgs.some((entry) => typeof entry !== "string")) {
+    return false;
+  }
+  if (typeof value.sessionWatcherEnabled !== "boolean") {
+    return false;
+  }
+  if (typeof value.watcherDir !== "string" || value.watcherDir.trim().length === 0) {
+    return false;
+  }
+  if (typeof value.bracketedPaste !== "boolean") {
+    return false;
+  }
+  if (value.cwd !== undefined && typeof value.cwd !== "string") {
+    return false;
+  }
+  return true;
+}
+
+function isRuntimeSessionReconnectInfo(
+  value: unknown
+): value is PersistedRTerminalState["runtime"] {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (typeof value.sessionId !== "string" || value.sessionId.trim().length === 0) {
+    return false;
+  }
+  if (!isPositiveInteger(value.port)) {
+    return false;
+  }
+  if (value.pid !== undefined && !isPositiveInteger(value.pid)) {
+    return false;
+  }
+  return true;
+}
+
+function isPersistedUiSnapshot(value: unknown): value is PersistedRTerminalState["ui"] {
+  if (!isObjectRecord(value) || !isPersistedReplaySnapshot(value.replay)) {
+    return false;
+  }
+  if (!isPositiveInteger(value.replayColumns) || !isPositiveInteger(value.replayRows)) {
+    return false;
+  }
+  if (!["starting", "ready", "executing", "reply", "closed"].includes(String(value.mode))) {
+    return false;
+  }
+  if (!["main", "cont"].includes(String(value.promptKind))) {
+    return false;
+  }
+  if (
+    typeof value.promptReady !== "boolean" ||
+    typeof value.promptVisible !== "boolean" ||
+    typeof value.replyPromptText !== "string" ||
+    typeof value.pendingPromptToken !== "boolean" ||
+    typeof value.pendingInitialPromptGap !== "boolean" ||
+    typeof value.lastWriteEndedWithNewline !== "boolean" ||
+    typeof value.hasReceivedOutput !== "boolean" ||
+    typeof value.inputText !== "string" ||
+    !isNonNegativeInteger(value.inputCursorPosition)
+  ) {
+    return false;
+  }
+  if (value.backendChildPid !== undefined && !isPositiveInteger(value.backendChildPid)) {
+    return false;
+  }
+  return true;
+}
+
+function isPersistedReplaySnapshot(
+  value: unknown
+): value is PersistedRTerminalState["ui"]["replay"] {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (!Array.isArray(value.lines) || value.lines.some((line) => typeof line !== "string")) {
+    return false;
+  }
+  return (
+    isNonNegativeInteger(value.finalRow) &&
+    isNonNegativeInteger(value.cursorRow) &&
+    isNonNegativeInteger(value.cursorCol)
+  );
+}
+
+function isPersistedTerminalContext(value: unknown): value is TerminalContext {
+  if (!isObjectRecord(value) || typeof value.kind !== "string") {
+    return false;
+  }
+  if (value.kind === "panel") {
+    return true;
+  }
+  return value.kind === "editor" && typeof value.viewColumn === "number";
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, any> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 async function handleTerminalClose(closedTerminal: vscode.Terminal): Promise<void> {
+  if (ignoredTerminalCloseEvents.has(closedTerminal)) {
+    ignoredTerminalCloseEvents.delete(closedTerminal);
+    terminalToRecord.delete(closedTerminal);
+    return;
+  }
+
   const record = resolveRecordFromTerminal(closedTerminal);
   if (!record) return;
 
-  terminalToRecord.delete(closedTerminal);
+  detachTerminalFromRecord(record, closedTerminal);
+
+  if (extensionHostDeactivating) {
+    return;
+  }
 
   if (record.location.kind === "editor") {
     return;
@@ -115,6 +465,284 @@ async function createRTerminal(
   );
 
   attachTerminal(record);
+  schedulePersistPersistentSessions();
+}
+
+async function managePersistentSessions(context: vscode.ExtensionContext): Promise<void> {
+  let sessions = await refreshManagedPersistentSessions();
+  if (sessions.length === 0) {
+    void vscode.window.showInformationMessage("No persistent R console sessions are running.");
+    return;
+  }
+
+  while (true) {
+    const action = await pickManageAction(sessions);
+    if (!action) {
+      return;
+    }
+
+    if (action.action === "refresh") {
+      sessions = await refreshManagedPersistentSessions();
+      if (sessions.length === 0) {
+        void vscode.window.showInformationMessage("No persistent R console sessions are running.");
+        return;
+      }
+      continue;
+    }
+
+    if (action.action === "attachAll") {
+      await attachPersistentSessions(sessions.filter((session) => !session.attached), context);
+      return;
+    }
+
+    if (action.action === "attach") {
+      const selected = await pickPersistentSessions(
+        sessions.filter((session) => !session.attached),
+        "Select persistent R console sessions to attach"
+      );
+      if (selected.length > 0) {
+        await attachPersistentSessions(selected, context);
+      }
+      return;
+    }
+
+    if (action.action === "closeAll") {
+      await closePersistentSessions(sessions, context);
+      return;
+    }
+
+    const selected = await pickPersistentSessions(
+      sessions,
+      "Select persistent R console sessions to close permanently"
+    );
+    if (selected.length > 0) {
+      await closePersistentSessions(selected, context);
+    }
+    return;
+  }
+}
+
+async function refreshManagedPersistentSessions(): Promise<ManagedPersistentSession[]> {
+  for (const entry of await loadPersistentSessionsFromDisk()) {
+    persistentSessionRecords.set(entry.terminal.runtime.sessionId, entry);
+  }
+  prunePersistentSessionRegistry();
+  const sessions = collectManagedPersistentSessions();
+  persistPersistentSessions();
+  return sessions;
+}
+
+function collectManagedPersistentSessions(): ManagedPersistentSession[] {
+  const sessions = new Map<string, ManagedPersistentSession>();
+
+  for (const entry of persistentSessionRecords.values()) {
+    const sessionId = entry.terminal.runtime.sessionId;
+    sessions.set(sessionId, {
+      sessionId,
+      entry,
+      pid: getPersistedRuntimePid(entry.terminal),
+      attached: false,
+    });
+  }
+
+  for (const record of new Set(rTerminalToRecord.values())) {
+    if (!record.rTerminal.isRunning()) {
+      continue;
+    }
+    const terminal = record.rTerminal.exportPersistentState();
+    if (!terminal) {
+      continue;
+    }
+    const sessionId = terminal.runtime.sessionId;
+    const entry: PersistedConsoleRecord = {
+      terminal,
+      location: record.location,
+    };
+    persistentSessionRecords.set(sessionId, entry);
+    sessions.set(sessionId, {
+      sessionId,
+      entry,
+      attachedRecord: record,
+      pid: getPersistedRuntimePid(terminal),
+      attached: true,
+    });
+  }
+
+  return [...sessions.values()]
+    .filter((session) => hasLivePersistedRuntime(session.entry))
+    .sort((left, right) => formatManagedSessionLabel(left).localeCompare(formatManagedSessionLabel(right)));
+}
+
+function prunePersistentSessionRegistry(): void {
+  for (const [sessionId, entry] of persistentSessionRecords) {
+    if (!hasLivePersistedRuntime(entry)) {
+      persistentSessionRecords.delete(sessionId);
+    }
+  }
+}
+
+async function pickManageAction(
+  sessions: readonly ManagedPersistentSession[]
+): Promise<ManageAction | undefined> {
+  const detachedCount = sessions.filter((session) => !session.attached).length;
+  const actions: ManageAction[] = [];
+
+  if (detachedCount > 0) {
+    actions.push(
+      {
+        label: "Attach Session...",
+        description: `${detachedCount} detached`,
+        action: "attach",
+      },
+      {
+        label: "Attach All Detached Sessions",
+        description: `${detachedCount} detached`,
+        action: "attachAll",
+      }
+    );
+  }
+
+  actions.push(
+    {
+      label: "Close Session...",
+      description: `${sessions.length} running`,
+      action: "close",
+    },
+    {
+      label: "Close All Sessions",
+      description: `${sessions.length} running`,
+      action: "closeAll",
+    },
+    {
+      label: "Refresh",
+      action: "refresh",
+    }
+  );
+
+  return vscode.window.showQuickPick(actions, {
+    placeHolder: "Manage persistent R console sessions",
+  });
+}
+
+async function pickPersistentSessions(
+  sessions: readonly ManagedPersistentSession[],
+  placeHolder: string
+): Promise<ManagedPersistentSession[]> {
+  if (sessions.length === 0) {
+    void vscode.window.showInformationMessage("No matching persistent R console sessions are running.");
+    return [];
+  }
+
+  const picks = sessions.map((session): ManagedSessionPick => ({
+    label: formatManagedSessionLabel(session),
+    description: session.attached ? "attached" : "detached",
+    detail: formatManagedSessionDetail(session),
+    session,
+  }));
+
+  const selected = await vscode.window.showQuickPick(picks, {
+    canPickMany: true,
+    placeHolder,
+  });
+  return selected?.map((pick) => pick.session) ?? [];
+}
+
+async function attachPersistentSessions(
+  sessions: readonly ManagedPersistentSession[],
+  context: vscode.ExtensionContext
+): Promise<void> {
+  for (const session of sessions) {
+    if (session.attachedRecord) {
+      revealConsoleRecord(session.attachedRecord);
+      continue;
+    }
+
+    if (!hasLivePersistedRuntime(session.entry)) {
+      persistentSessionRecords.delete(session.sessionId);
+      continue;
+    }
+
+    const options = buildPersistentTerminalOptions(session.entry.terminal.options);
+    if (!options) {
+      continue;
+    }
+
+    const rTerminal = new RTerminal(options, context.extensionPath, session.entry.terminal);
+    const record = createConsoleRecord(rTerminal, session.entry.location);
+    attachTerminal(record, true);
+  }
+  schedulePersistPersistentSessions();
+}
+
+function revealConsoleRecord(record: ConsoleRecord): void {
+  if (record.terminal) {
+    record.terminal.show(false);
+    return;
+  }
+  reattachRunningTerminal(record);
+}
+
+async function closePersistentSessions(
+  sessions: readonly ManagedPersistentSession[],
+  context: vscode.ExtensionContext
+): Promise<void> {
+  const liveSessions = sessions.filter((session) => hasLivePersistedRuntime(session.entry));
+  if (liveSessions.length === 0) {
+    void vscode.window.showInformationMessage("No selected persistent R console sessions are still running.");
+    return;
+  }
+
+  const result = await vscode.window.showWarningMessage(
+    `Close ${liveSessions.length} persistent R console session${liveSessions.length === 1 ? "" : "s"} permanently?`,
+    { modal: true },
+    "Close"
+  );
+  if (result !== "Close") {
+    return;
+  }
+
+  const detachedSessions = liveSessions.filter((session) => !session.attachedRecord);
+  closeDetachedPersistentSessions(detachedSessions, context);
+
+  for (const session of liveSessions) {
+    if (session.attachedRecord) {
+      closeConsoleRecordPermanently(session.attachedRecord);
+    }
+  }
+
+  persistPersistentSessions();
+}
+
+function closeDetachedPersistentSessions(
+  sessions: readonly ManagedPersistentSession[],
+  context: vscode.ExtensionContext
+): void {
+  if (sessions.length === 0) {
+    return;
+  }
+
+  const backend = createRuntimeBackend(context.extensionPath);
+  if (!backend) {
+    void vscode.window.showErrorMessage("R Console sidecar backend not found; detached sessions could not be closed.");
+    return;
+  }
+
+  for (const session of sessions) {
+    const handle = backend.reconnect(session.entry.terminal.runtime);
+    backend.close(handle);
+    persistentSessionRecords.delete(session.sessionId);
+  }
+}
+
+function formatManagedSessionLabel(session: ManagedPersistentSession): string {
+  return typeof session.pid === "number"
+    ? `R Console (${session.pid})`
+    : `R Console (${session.sessionId.slice(0, 8)})`;
+}
+
+function formatManagedSessionDetail(session: ManagedPersistentSession): string {
+  const cwd = session.entry.terminal.options.cwd || "default working directory";
+  return `cwd: ${cwd} | session: ${session.sessionId}`;
 }
 
 async function ensureConfiguredRPath(): Promise<void> {
@@ -176,10 +804,12 @@ function createConsoleRecord(
 
   record.pidSubscription = rTerminal.onDidChangePid((pid) => {
     updateConsoleRecordPid(record, pid);
+    schedulePersistPersistentSessions();
   });
 
   rTerminalToRecord.set(rTerminal, record);
   updateConsoleRecordPid(record, rTerminal.getPid());
+  schedulePersistPersistentSessions();
   return record;
 }
 
@@ -199,9 +829,20 @@ function updateConsoleRecordPid(
 
   if (typeof pid === "number" && Number.isFinite(pid) && pid > 0) {
     pidToRecord.set(pid, record);
-    syncTerminalRecordForPid(pid);
     syncConsoleRecordLocationFromTabs(record);
   }
+  schedulePersistPersistentSessions();
+}
+
+function detachTerminalFromRecord(
+  record: ConsoleRecord,
+  terminal: vscode.Terminal
+): void {
+  terminalToRecord.delete(terminal);
+  if (record.terminal === terminal) {
+    record.terminal = undefined;
+  }
+  schedulePersistPersistentSessions();
 }
 
 function disposeConsoleRecord(record: ConsoleRecord): void {
@@ -217,6 +858,45 @@ function disposeConsoleRecord(record: ConsoleRecord): void {
       terminalToRecord.delete(terminal);
     }
   }
+  record.terminal = undefined;
+  schedulePersistPersistentSessions();
+}
+
+function closeConsoleRecordPermanently(
+  record: ConsoleRecord,
+  terminalToDispose: vscode.Terminal | undefined = record.terminal
+): void {
+  forgetPersistentSessionForRecord(record);
+  disposeConsoleRecord(record);
+  record.rTerminal.forceClose();
+  if (terminalToDispose) {
+    terminalToRecord.delete(terminalToDispose);
+    terminalToDispose.dispose();
+  }
+}
+
+function forgetPersistentSessionForRecord(record: ConsoleRecord): void {
+  const sessionId = getPersistentSessionIdForRecord(record);
+  if (sessionId) {
+    persistentSessionRecords.delete(sessionId);
+  }
+}
+
+function getPersistentSessionIdForRecord(record: ConsoleRecord): string | undefined {
+  const state = record.rTerminal.exportPersistentState();
+  if (state?.runtime.sessionId) {
+    return state.runtime.sessionId;
+  }
+
+  if (typeof record.pid !== "number") {
+    return undefined;
+  }
+  for (const [sessionId, entry] of persistentSessionRecords) {
+    if (getPersistedRuntimePid(entry.terminal) === record.pid) {
+      return sessionId;
+    }
+  }
+  return undefined;
 }
 
 function reattachRunningTerminal(record: ConsoleRecord): vscode.Terminal {
@@ -225,25 +905,32 @@ function reattachRunningTerminal(record: ConsoleRecord): vscode.Terminal {
 }
 
 async function handleRunningConsoleClose(record: ConsoleRecord): Promise<void> {
-  if (!record.rTerminal.isRunning()) {
+  if (closeConfirmationInProgress.has(record)) {
+    return;
+  }
+
+  if (!record.rTerminal.requiresCloseConfirmation()) {
+    forgetPersistentSessionForRecord(record);
     disposeConsoleRecord(record);
     return;
   }
 
-  const reattachedTerminal = reattachRunningTerminal(record);
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  closeConfirmationInProgress.add(record);
+  try {
+    const reattachedTerminal = reattachRunningTerminal(record);
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
-  const result = await vscode.window.showWarningMessage(
-    "Are you sure you want to close the R console?",
-    { modal: true },
-    "Close"
-  );
+    const result = await vscode.window.showWarningMessage(
+      "Are you sure you want to close the R console?",
+      { modal: true },
+      "Close"
+    );
 
-  if (result === "Close") {
-    disposeConsoleRecord(record);
-    record.rTerminal.forceClose();
-    terminalToRecord.delete(reattachedTerminal);
-    reattachedTerminal.dispose();
+    if (result === "Close") {
+      closeConsoleRecordPermanently(record, reattachedTerminal);
+    }
+  } finally {
+    closeConfirmationInProgress.delete(record);
   }
 }
 
@@ -252,11 +939,12 @@ function attachTerminal(
   preserveFocusOverride?: boolean
 ): vscode.Terminal {
   const terminalOptions: vscode.ExtensionTerminalOptions = {
-    name: VSCODE_R_TERMINAL_NAME,
+    name: record.rTerminal.getTerminalName(),
     pty: record.rTerminal,
     iconPath: extensionBaseUri
       ? vscode.Uri.joinPath(extensionBaseUri, "images", "Rlogo.png")
-      : new vscode.ThemeIcon("terminal")
+      : new vscode.ThemeIcon("terminal"),
+    isTransient: true,
   };
 
   if (record.location.kind === "editor") {
@@ -264,6 +952,10 @@ function attachTerminal(
   }
 
   const terminal = vscode.window.createTerminal(terminalOptions);
+  if (record.terminal) {
+    terminalToRecord.delete(record.terminal);
+  }
+  record.terminal = terminal;
   terminalToRecord.set(terminal, record);
 
   const alwaysUseActive = vscode.workspace.getConfiguration("r").get<boolean>("alwaysUseActiveTerminal");
@@ -301,16 +993,7 @@ function resolveRecordFromTerminal(
     }
   }
 
-  const pid = parseConsolePidFromTerminal(terminal);
-  if (typeof pid !== "number") {
-    return undefined;
-  }
-
-  const record = pidToRecord.get(pid);
-  if (record) {
-    terminalToRecord.set(terminal, record);
-  }
-  return record;
+  return undefined;
 }
 
 function syncTerminalRecordsFromWindow(): void {
@@ -326,23 +1009,6 @@ function syncTerminalRecord(terminal: vscode.Terminal): void {
 
   const record = resolveRecordFromTerminal(terminal);
   if (record) {
-    terminalToRecord.set(terminal, record);
-  }
-}
-
-function syncTerminalRecordForPid(pid: number): void {
-  const record = pidToRecord.get(pid);
-  if (!record) {
-    return;
-  }
-
-  for (const terminal of vscode.window.terminals) {
-    if (terminalToRecord.has(terminal)) {
-      continue;
-    }
-    if (parseConsolePidFromTerminal(terminal) !== pid) {
-      continue;
-    }
     terminalToRecord.set(terminal, record);
   }
 }
@@ -382,7 +1048,7 @@ function getTerminalCandidateNames(terminal: vscode.Terminal): string[] {
 }
 
 function parseConsolePidFromLabel(label: string): number | undefined {
-  const match = label.match(/^R Console \((\d+)\)$/);
+  const match = label.match(R_CONSOLE_PID_LABEL_PATTERN);
   if (!match) {
     return undefined;
   }
@@ -413,6 +1079,7 @@ function handleTerminalTabChange(event: vscode.TabChangeEvent): void {
       kind: "editor",
       viewColumn: tab.group.viewColumn,
     };
+    schedulePersistPersistentSessions();
   }
 
   for (const tab of event.closed) {
@@ -430,6 +1097,10 @@ function handleTerminalTabChange(event: vscode.TabChangeEvent): void {
 }
 
 async function handleEditorTerminalTabClosed(pid: number): Promise<void> {
+  if (ignoredEditorClosePids.has(pid)) {
+    return;
+  }
+
   if (editorCloseInProgress.has(pid)) {
     return;
   }
@@ -470,6 +1141,7 @@ function syncConsoleRecordLocationFromTabs(record: ConsoleRecord): void {
     kind: "editor",
     viewColumn: tab.group.viewColumn,
   };
+  schedulePersistPersistentSessions();
 }
 
 function findEditorTabByPid(pid: number): vscode.Tab | undefined {
@@ -489,11 +1161,103 @@ function findEditorTabByPid(pid: number): vscode.Tab | undefined {
 }
 
 export function deactivate() {
+  extensionHostDeactivating = true;
+  flushPersistPersistentSessions();
   for (const record of new Set(rTerminalToRecord.values())) {
     record.pidSubscription.dispose();
-    record.rTerminal.forceClose();
+    record.rTerminal.dispose();
   }
   terminalToRecord.clear();
   rTerminalToRecord.clear();
   pidToRecord.clear();
+}
+
+function startPersistentSessionRegistry(context: vscode.ExtensionContext): void {
+  persistHeartbeatTimer = setInterval(() => {
+    if (rTerminalToRecord.size > 0 || persistentSessionRecords.size > 0) {
+      persistPersistentSessions();
+    }
+  }, PERSIST_HEARTBEAT_MS);
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      if (persistHeartbeatTimer) {
+        clearInterval(persistHeartbeatTimer);
+        persistHeartbeatTimer = undefined;
+      }
+      if (persistDebounceTimer) {
+        clearTimeout(persistDebounceTimer);
+        persistDebounceTimer = undefined;
+      }
+    })
+  );
+}
+
+function schedulePersistPersistentSessions(): void {
+  if (!persistentSessionFilePath || persistDebounceTimer) {
+    return;
+  }
+  persistDebounceTimer = setTimeout(() => {
+    persistDebounceTimer = undefined;
+    persistPersistentSessions();
+  }, PERSIST_DEBOUNCE_MS);
+}
+
+function flushPersistPersistentSessions(): void {
+  if (persistDebounceTimer) {
+    clearTimeout(persistDebounceTimer);
+    persistDebounceTimer = undefined;
+  }
+  persistPersistentSessions();
+}
+
+function persistPersistentSessions(): void {
+  if (!persistentSessionFilePath) {
+    return;
+  }
+
+  const sessionMap = new Map(persistentSessionRecords);
+  for (const record of new Set(rTerminalToRecord.values())) {
+    if (!record.rTerminal.isRunning()) {
+      continue;
+    }
+    const terminal = record.rTerminal.exportPersistentState();
+    if (!terminal) {
+      continue;
+    }
+    sessionMap.set(terminal.runtime.sessionId, {
+      terminal,
+      location: record.location,
+    });
+  }
+
+  const persisted = [...sessionMap.values()].filter(hasLivePersistedRuntime);
+  persistentSessionRecords.clear();
+  for (const entry of persisted) {
+    persistentSessionRecords.set(entry.terminal.runtime.sessionId, entry);
+  }
+
+  if (persisted.length === 0) {
+    try {
+      fs.rmSync(persistentSessionFilePath, { force: true });
+      if (legacyReloadSessionFilePath) {
+        fs.rmSync(legacyReloadSessionFilePath, { force: true });
+      }
+    } catch {
+    }
+    return;
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(persistentSessionFilePath), {
+      recursive: true,
+    });
+    const sessionState: PersistentSessionState = {
+      sessions: persisted,
+    };
+    fs.writeFileSync(persistentSessionFilePath, JSON.stringify(sessionState), "utf8");
+    if (legacyReloadSessionFilePath) {
+      fs.rmSync(legacyReloadSessionFilePath, { force: true });
+    }
+  } catch {
+  }
 }


### PR DESCRIPTION
Summary
This revised PR adds a true self-managed R Console session model. R Console now owns its embedded backend session independently, while still using vscode-R only for configuration, bootstrap, and session metadata.

Main Changes
 - Added persistent self-managed console sessions that can survive VS Code terminal UI detaches.
 - Added a session manager for attaching to or closing running R Console sessions.
 - Reworked the backend/UI transport to use a TCP session server with reconnect metadata.
 - Persisted console runtime state, terminal replay state, prompt/input state, and terminal location for later reattach.
 - Kept the vscode-R boundary read-only for session metadata without managing or replacing the vscode-R session.




