### PR TITLE
Add persistent session detach commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to R Console will be documented in this file.
 
+## [0.2.3] - 2026-05-10
+
+### Added
+- Added persistent-session detach actions that remove the VS Code console UI without closing the running R backend session.
+
+### Changed
+- Removed the old `reload-sessions.json` persistent-session compatibility path; current sessions now use only `persistent-sessions.json`.
+- Removed redundant source comments while keeping comments that document non-obvious terminal, R, and platform behavior.
+
 ## [0.2.2] - 2026-05-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Implementation details are documented in [docs/IMPLEMENTATION.md](docs/IMPLEMENT
 - Custom R console hosted in the VS Code terminal area.
 - Embedded console backend for macOS, Linux, and Windows
 - Session watcher integration with vscode-R for search-path data, global-environment data, and runtime `$` / `@` member completion.
-- Self-managed R console sessions that can be attached to or closed from VS Code.
+- Self-managed R console sessions that can be attached, detached, or closed from VS Code.
 - Console-scoped completion and signature help through R's `languageserver` package.
 - Immediate local syntax highlighting plus semantic-token styling also through `languageserver`.
 - Multiline editing with local history navigation, reverse search, and a windowed/collapsed viewport renderer for long inputs.
@@ -29,8 +29,9 @@ https://github.com/user-attachments/assets/d4877829-07e9-42c2-a66b-652695a5ebf4
 - [vscode-R](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r). This extension declares `REditorSupport.r` in `extensionDependencies` and depends on vscode-R session bootstrap/configuration; there is no standalone startup path.
   
 > [!IMPORTANT]
-> Only vscode-R official release v2.8.* gets supported as the new version moves to a WebSockets & JSON-RPC 2.0 based approach.
-  
+> Only official vscode-R 2.8.x releases are currently supported. Newer vscode-R builds are moving to a WebSocket and JSON-RPC 2.0 based architecture.
+> A future R Console update will support both vscode-R architectures once the new architecture is officially released.
+
 - The R package `languageserver` if you want completion, signature help, and semantic highlighting.
 - Rust/Cargo only if you are building the sidecar binaries from source.
 
@@ -42,7 +43,7 @@ Launch `R Console` from the Command Palette with:
 - `R Console: Create R Console in Side Editor`
 - `R Console: Manage Persistent Sessions...`
 
-Use the session manager to attach to or close running R Console sessions.
+Use the session manager to attach to, detach from, or close running R Console sessions.
 
 The minimum vscode-R setup for R Console commands to work is:
 
@@ -86,7 +87,7 @@ npm run stage:sidecar
 npm run package
 ```
 
-This produces a target-specific VSIX for the current host platform, for example `vsc-r-console-0.2.2-win32-x64.vsix`.
+This produces a target-specific VSIX for the current host platform, for example `vsc-r-console-0.2.3-win32-x64.vsix`.
 
 `vscode:prepublish` still prepares the production bundle and stages the current platform binary into `bundled/bin/`.
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -550,6 +550,7 @@ separate from the `vscode-R` session watcher.
 - `start(args, options)`
 - `reconnect(info)`
 - `attach(session, handlers)`
+- `detach(session)`
 - `sendSessionCommand(session, command)`
 - `requestParseStatus(session, code)`
 - `close(session)`
@@ -585,10 +586,7 @@ snapshot.
 
 ### 4.3 Registry Loading And Pruning
 
-On activation, `extension.ts` loads:
-
-- `persistent-sessions.json`
-- legacy `reload-sessions.json`
+On activation, `extension.ts` loads `persistent-sessions.json`.
 
 Records are validated before use. A record is kept only when:
 
@@ -628,7 +626,11 @@ Attaching a detached console follows this implementation path:
 
 No new embedded R backend is started for a reconnect.
 
-### 4.6 Closing A Managed Console
+### 4.6 Detaching Or Closing A Managed Console
+
+Attached console detach persists the latest reconnect/UI state, disconnects the
+frontend socket, disposes the VS Code terminal UI, and leaves the backend session
+running for the next session-manager attach.
 
 Attached console close uses the active `RTerminal` and active runtime session.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsc-r-console",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsc-r-console",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/headless": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-r-console",
   "displayName": "R Console for VS Code",
   "description": "A lightweight R console for VS Code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "RConsole",
   "license": "MIT",
   "icon": "images/Rlogo.png",

--- a/src/Language/virtualRDocument.ts
+++ b/src/Language/virtualRDocument.ts
@@ -45,7 +45,6 @@ export class VirtualRDocument {
       if (remaining <= lineLen) {
         return new vscode.Position(line, remaining);
       }
-      // Account for newline char.
       remaining -= lineLen + 1;
     }
     const last = lines.length - 1;

--- a/src/Runtime/runtimeBackend.ts
+++ b/src/Runtime/runtimeBackend.ts
@@ -98,6 +98,7 @@ export interface RuntimeBackend {
   start(args: string[], options: RuntimeBackendStartOptions): RuntimeSessionHandle;
   reconnect(info: RuntimeSessionReconnectInfo): RuntimeSessionHandle;
   attach(session: RuntimeSessionHandle, handlers: RuntimeBackendHandlers): void;
+  detach(session: RuntimeSessionHandle): void;
   hasCapability(session: RuntimeSessionHandle | null, capability: BackendCapability): boolean;
   canUseSessionCommands(session: RuntimeSessionHandle | null): boolean;
   sendSessionCommand(session: RuntimeSessionHandle | null, command: RuntimeSessionCommand): boolean;
@@ -230,6 +231,21 @@ export class RustSidecarRuntimeBackend implements RuntimeBackend {
     }
 
     void this.attachSocket(state, generation);
+  }
+
+  detach(session: RuntimeSessionHandle): void {
+    const state = this.sessionStates.get(session);
+    if (!state) {
+      return;
+    }
+
+    state.attachGeneration += 1;
+    state.handlers = undefined;
+    state.hostConnected = false;
+    state.socketCarry = Buffer.alloc(0);
+    this.resolvePendingParseRequests(state, 1);
+    state.socket?.destroy();
+    state.socket = undefined;
   }
 
   canUseSessionCommands(session: RuntimeSessionHandle | null): boolean {

--- a/src/Runtime/sessionWatcher.ts
+++ b/src/Runtime/sessionWatcher.ts
@@ -188,8 +188,6 @@ export class SessionWatcher {
       const content = fs.readFileSync(requestFile, "utf-8");
       const request = JSON.parse(content) as SessionRequest;
 
-      // Sidecar mode does not know child R PID up front; auto-pin to the first
-      // fresh attach request so updates stay scoped to one session (v1 behavior).
       if (
         this.expectedPid === undefined &&
         request.command === "attach" &&
@@ -199,9 +197,7 @@ export class SessionWatcher {
         this.expectedPidAutoPinned = true;
       }
       
-      // PID filtering: only process requests from our expected R session
       if (this.expectedPid !== undefined && request.pid !== this.expectedPid) {
-        // This request is from a different R session, ignore it
         return;
       }
       
@@ -228,12 +224,9 @@ export class SessionWatcher {
       }
       this.sessionDir = nextSessionDir;
       this.workspaceData = undefined;
-      // isAttached() is now true — notify immediately so PID/state updates do
-      // not wait for the next 100ms poll tick.
       this.onAttachCallback?.();
       this.startWorkspaceWatcher();
     } catch {
-      // Ignore malformed request files
     }
   }
 
@@ -284,7 +277,6 @@ export class SessionWatcher {
       this.workspaceData = JSON.parse(content) as WorkspaceData;
       this.onChangeCallback?.(this.workspaceData);
     } catch {
-      // Ignore malformed workspace data
     }
   }
 

--- a/src/Terminal/inputState.ts
+++ b/src/Terminal/inputState.ts
@@ -31,90 +31,70 @@ export class InputState {
     this._cursorPosition = Math.max(0, Math.min(value, this._text.length));
   }
 
-  /** Array of all lines (split by \n) */
   get lines(): string[] {
     return this._text.split("\n");
   }
 
-  /** Current row (0-based) */
   get cursorRow(): number {
     const textBefore = this._text.slice(0, this._cursorPosition);
     return (textBefore.match(/\n/g) || []).length;
   }
 
-  /** Current column (0-based) */
   get cursorCol(): number {
     const textBefore = this._text.slice(0, this._cursorPosition);
     const lastNewline = textBefore.lastIndexOf("\n");
     return lastNewline === -1 ? this._cursorPosition : this._cursorPosition - lastNewline - 1;
   }
 
-  /** Text on the current line */
   get currentLine(): string {
     return this.lines[this.cursorRow];
   }
 
-  /** Text before cursor on current line */
   get currentLineBeforeCursor(): string {
     const line = this.currentLine;
     return line.slice(0, this.cursorCol);
   }
 
-  /** Text after cursor on current line */
   get currentLineAfterCursor(): string {
     const line = this.currentLine;
     return line.slice(this.cursorCol);
   }
 
-  /** Text before cursor (entire document) */
   get textBeforeCursor(): string {
     return this._text.slice(0, this._cursorPosition);
   }
 
-  /** Text after cursor (entire document) */
   get textAfterCursor(): string {
     return this._text.slice(this._cursorPosition);
   }
 
-  /** Character at cursor position (or empty string if at end) */
   get currentChar(): string {
     return this._text[this._cursorPosition] || "";
   }
 
-  /** Character before cursor (or empty string if at start) */
   get charBeforeCursor(): string {
     return this._cursorPosition > 0 ? this._text[this._cursorPosition - 1] : "";
   }
 
-  /** True when cursor is at the end of the text */
   get isAtEnd(): boolean {
     return this._cursorPosition === this._text.length;
   }
 
-  /** True when cursor is at the start of the text */
   get isAtStart(): boolean {
     return this._cursorPosition === 0;
   }
 
-  /** 
-   * Get the starting index of each line in the text.
-   * Line 0 starts at index 0, line 1 starts after first \n, etc.
-   */
   private getLineStartIndexes(): number[] {
     const indexes = [0];
     let pos = 0;
     for (const line of this.lines) {
-      pos += line.length + 1; // +1 for \n
+      pos += line.length + 1;
       indexes.push(pos);
     }
-    indexes.pop(); // Remove last (beyond end of text)
+    indexes.pop();
     return indexes;
   }
 
-  /**
-   * Translate (row, col) to absolute cursor position.
-   * Clamps to valid range.
-   */
   translateRowColToIndex(row: number, col: number): number {
     const lines = this.lines;
     row = Math.max(0, Math.min(row, lines.length - 1));
@@ -126,32 +106,18 @@ export class InputState {
     return lineStart + col;
   }
 
-  /**
-   * Get relative position for moving cursor left.
-   * Only moves within the current line (stops at line start).
-   */
   getCursorLeftPosition(count: number = 1): number {
     return -Math.min(this.cursorCol, count);
   }
 
-  /**
-   * Get relative position for moving cursor right.
-   * Only moves within the current line (stops at line end).
-   */
   getCursorRightPosition(count: number = 1): number {
     return Math.min(count, this.currentLineAfterCursor.length);
   }
 
-  /**
-   * Get position of start of current line.
-   */
   getStartOfLinePosition(): number {
     return -this.cursorCol;
   }
 
-  /**
-   * Get position of end of current line.
-   */
   getEndOfLinePosition(): number {
     return this.currentLine.length - this.cursorCol;
   }
@@ -166,42 +132,25 @@ export class InputState {
     this.preferredColumn = null;
   }
 
-  /**
-   * Auto up: Move cursor up if not on first line, otherwise return "history"
-   * to indicate caller should navigate history.
-   */
   autoUp(renderMetrics: InputRenderMetrics): "moved" | "history" {
     return this.moveByRenderedRows(-1, renderMetrics) ? "moved" : "history";
   }
 
-  /**
-   * Auto down: Move cursor down if not on last line, otherwise return "history"
-   * to indicate caller should navigate history.
-   */
   autoDown(renderMetrics: InputRenderMetrics): "moved" | "history" {
     return this.moveByRenderedRows(1, renderMetrics) ? "moved" : "history";
   }
 
-  /**
-   * Move cursor to end of text.
-   */
   cursorToEnd(): void {
     this._cursorPosition = this._text.length;
     this.preferredColumn = null;
   }
 
-  /**
-   * Insert text at cursor position.
-   */
   insertText(text: string): void {
     this._text = this._text.slice(0, this._cursorPosition) + text + this._text.slice(this._cursorPosition);
     this._cursorPosition += text.length;
     this.preferredColumn = null;
   }
 
-  /**
-   * Delete characters before cursor. Returns deleted text.
-   */
   deleteBeforeCursor(count: number = 1): string {
     const deleteCount = Math.min(count, this._cursorPosition);
     const deleted = this._text.slice(this._cursorPosition - deleteCount, this._cursorPosition);
@@ -211,9 +160,6 @@ export class InputState {
     return deleted;
   }
 
-  /**
-   * Delete characters after cursor. Returns deleted text.
-   */
   deleteAfterCursor(count: number = 1): string {
     const deleteCount = Math.min(count, this._text.length - this._cursorPosition);
     const deleted = this._text.slice(this._cursorPosition, this._cursorPosition + deleteCount);
@@ -228,9 +174,6 @@ export class InputState {
     this.preferredColumn = null;
   }
 
-  /**
-   * Apply a history entry (replace entire text, cursor at end).
-   */
   applyHistoryEntry(entry: string | null): void {
     if (entry === null) {
       this._text = "";
@@ -297,10 +240,6 @@ export class InputState {
     return null;
   }
 
-  /**
-   * Check if cursor is inside a string, backtick identifier, or special operator (simplified heuristic).
-   * Counts unescaped quotes/backticks/percent signs before cursor.
-   */
   isInString(): boolean {
     const beforeCursor = this.textBeforeCursor;
     let inSingleQuote = false;
@@ -328,41 +267,23 @@ export class InputState {
     return inSingleQuote || inDoubleQuote || inBacktick || inPercent;
   }
 
-  /**
-   * Check if character after cursor allows auto-bracket insertion.
-   * Auto-close is allowed when followed by `,)}\]` whitespace, or end of line.
-   */
   canAutoCloseBracket(): boolean {
     const after = this.currentChar;
     return after === "" || /^[,)}\]\s]/.test(after);
   }
 
-  /**
-   * Get the matching closing bracket for an opening bracket.
-   */
   getClosingBracket(openBracket: string): string | undefined {
     return InputState.BRACKET_PAIRS[openBracket];
   }
 
-  /**
-   * Check if a character is a closing bracket.
-   */
   isClosingBracket(ch: string): boolean {
     return InputState.CLOSING_BRACKETS.has(ch);
   }
 
-  /**
-   * Check if cursor is between curly braces {|}.
-   * Only {|} triggers multiline expansion on Enter.
-   */
   isBetweenCurlyBraces(): boolean {
     return this.charBeforeCursor === "{" && this.currentChar === "}";
   }
 
-  /**
-   * Check if cursor is between matching bracket pairs for backspace deletion.
-   * Includes (), [], {}, "", '', ``
-   */
   isBetweenMatchingPair(): boolean {
     const before = this.charBeforeCursor;
     const after = this.currentChar;
@@ -376,10 +297,6 @@ export class InputState {
     );
   }
 
-  /**
-   * Calculate indentation for a new line based on bracket depth.
-   * Returns the number of spaces to indent.
-   */
   calculateNewLineIndent(tabSize: number = 2): number {
     const currentBefore = this.currentLineBeforeCursor;
     const currentLineIsCommentOnly = /^\s*#/.test(currentBefore.trimEnd());
@@ -404,10 +321,6 @@ export class InputState {
     return baseIndent;
   }
 
-  /**
-   * Check if we should dedent when typing a closing bracket.
-   * Returns the number of spaces to remove (0 if no dedent needed).
-   */
   calculateClosingBracketDedent(tabSize: number = 2): number {
     const beforeOnLine = this.currentLineBeforeCursor;
     if (!/^\s*$/.test(beforeOnLine)) {

--- a/src/Terminal/keyProcessor.ts
+++ b/src/Terminal/keyProcessor.ts
@@ -22,7 +22,6 @@ export type KeyAction =
   | { type: "paste-end" }
   | { type: "text"; text: string };
 
-// CSI sequences (ESC [) - 6 characters
 const CSI_6: Map<string, KeyAction> = new Map([
   ["\x1b[200~", { type: "paste-start" }],
   ["\x1b[201~", { type: "paste-end" }],
@@ -30,7 +29,6 @@ const CSI_6: Map<string, KeyAction> = new Map([
   ["\x1b[1;5D", { type: "word-left" }],
 ]);
 
-// CSI sequences - 4 characters
 const CSI_4: Map<string, KeyAction> = new Map([
   ["\x1b[3~", { type: "delete" }],
   ["\x1b[1~", { type: "home" }],
@@ -41,7 +39,6 @@ const CSI_4: Map<string, KeyAction> = new Map([
   ["\x1b[5D", { type: "word-left" }],
 ]);
 
-// CSI sequences - 3 characters
 const CSI_3: Map<string, KeyAction> = new Map([
   ["\x1b[A", { type: "arrow", dir: "up" }],
   ["\x1b[B", { type: "arrow", dir: "down" }],
@@ -52,7 +49,6 @@ const CSI_3: Map<string, KeyAction> = new Map([
   ["\x1b[Z", { type: "backtab" }],
 ]);
 
-// SS3 sequences (ESC O) - Application cursor mode - 3 characters
 const SS3_3: Map<string, KeyAction> = new Map([
   ["\x1bOA", { type: "arrow", dir: "up" }],
   ["\x1bOB", { type: "arrow", dir: "down" }],
@@ -64,14 +60,12 @@ const SS3_3: Map<string, KeyAction> = new Map([
   ["\x1bOd", { type: "word-left" }],
 ]);
 
-// Alt key sequences (ESC + char) - 2 characters
 const ALT_2: Map<string, KeyAction> = new Map([
   ["\x1bb", { type: "word-left" }],
   ["\x1bf", { type: "word-right" }],
   ["\x1b\t", { type: "backtab" }],
 ]);
 
-// Control character codes
 const CTRL_CODES: Map<number, KeyAction> = new Map([
   [1, { type: "ctrl_a" }],
   [3, { type: "ctrl_c" }],
@@ -115,9 +109,6 @@ function getCsiAction(sequence: string): KeyAction | undefined {
   return undefined;
 }
 
-/**
- * Parse terminal input (VT100-ish) into high-level key actions.
- */
 export class KeyProcessor {
   private escapeBuffer = "";
   private inPaste = false;

--- a/src/Terminal/rTerminal.ts
+++ b/src/Terminal/rTerminal.ts
@@ -2414,6 +2414,28 @@ export class RTerminal implements vscode.Pseudoterminal {
     this.terminalState.dispose();
   }
 
+  detachPersistentSession(): PersistedRTerminalState | undefined {
+    const runtimeBackend = this.runtimeBackend;
+    const runtimeSession = this.rProcess;
+    if (!runtimeBackend || !runtimeSession) {
+      return undefined;
+    }
+
+    const state = this.exportPersistentState();
+    if (!state) {
+      return undefined;
+    }
+
+    runtimeBackend.detach(runtimeSession);
+    this.rProcess = null;
+    this.backendChildPid = undefined;
+    this.sessionHostConnected = false;
+    this.mode = "closed";
+    this.dispose();
+    this.terminalState.dispose();
+    return state;
+  }
+
   reattachToNewTerminal(): void {
     this.clearPromptRenderTimer();
     this.clearReplyPromptRenderTimer();

--- a/src/Terminal/renderer.ts
+++ b/src/Terminal/renderer.ts
@@ -8,17 +8,11 @@ type RenderPromptKind = "main" | "cont";
 
 export class Renderer {
   renderedLineCount = 1;
-  /** The row (0-indexed from render start) where cursor is positioned after render */
   cursorRowFromTop = 0;
-  /** The prompt to display (default "R> ") */
   promptText = "R> ";
-  /** The ANSI color for the prompt */
   promptColor = ANSI.brightGreen;
-  /** The prompt length for cursor calculations */
   promptLen = 3;
-  /** The continuation prompt to display for multiline input */
   continuationPromptText: string | null = null;
-  /** The ANSI color for the continuation prompt */
   continuationPromptColor = ANSI.reset;
   private readonly write: (text: string) => void;
   private lineHighlighter: RendererLineHighlighter | undefined;
@@ -44,10 +38,6 @@ export class Renderer {
     this.continuationPromptColor = ANSI.reset;
   }
 
-  /**
-   * Render with 2D cursor position (row, col).
-   * This is the new preferred method for multi-line editing.
-   */
   renderWithCursor(
     lines: string[],
     cursorRow: number,
@@ -104,17 +94,11 @@ export class Renderer {
     }
     const areaRows = this.renderedLineCount;
 
-    // Move to start of render area
-    // The cursor is currently at row `cursorRowFromTop` within the render area
-    // Move up from there to the top of the render area (row 0)
     this.write("\r");
     if (this.cursorRowFromTop > 0) {
       this.write(`\x1b[${this.cursorRowFromTop}A`);
     }
-    // Clear only the previously rendered lines, not beyond
-    // Use \x1b[K (clear line) for each line instead of \x1b[J (clear to end of screen)
     clearRenderedArea(areaRows);
-    // Move back to the top of render area
     if (areaRows > 1) {
       this.write(`\x1b[${areaRows - 1}A\r`);
     } else {
@@ -133,8 +117,6 @@ export class Renderer {
       this.write(prompt + line);
     });
 
-    // Calculate cursor position in terminal
-    // Sum up wrapped rows for lines before cursor line
     const prefixRows = lineRows.slice(0, cursorRow).reduce((sum, n) => sum + n, 0);
     const pLen =
       getPromptKind(cursorRow) === "main"
@@ -151,7 +133,6 @@ export class Renderer {
     }
     this.write(`\r\x1b[${col}G`);
 
-    // Track where the cursor actually is (for clearInputRender)
     this.cursorRowFromTop = terminalRow;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ type ManagedPersistentSession = {
 };
 
 type ManageAction = vscode.QuickPickItem & {
-  action: "attach" | "attachAll" | "close" | "closeAll" | "refresh";
+  action: "attach" | "attachAll" | "detach" | "detachAll" | "close" | "closeAll" | "refresh";
 };
 
 type ManagedSessionPick = vscode.QuickPickItem & {
@@ -63,7 +63,6 @@ const PERSIST_DEBOUNCE_MS = 250;
 const PERSIST_HEARTBEAT_MS = 5000;
 let extensionBaseUri: vscode.Uri | undefined;
 let persistentSessionFilePath: string | undefined;
-let legacyReloadSessionFilePath: string | undefined;
 let persistDebounceTimer: NodeJS.Timeout | undefined;
 let persistHeartbeatTimer: NodeJS.Timeout | undefined;
 let extensionHostDeactivating = false;
@@ -91,10 +90,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   persistentSessionFilePath = vscode.Uri.joinPath(
     sessionStorageUri,
     "persistent-sessions.json"
-  ).fsPath;
-  legacyReloadSessionFilePath = vscode.Uri.joinPath(
-    sessionStorageUri,
-    "reload-sessions.json"
   ).fsPath;
   void fs.promises.mkdir(sessionStorageUri.fsPath, { recursive: true }).catch(() => {});
   await initializePersistentSessionRegistry();
@@ -146,11 +141,8 @@ async function initializePersistentSessionRegistry(): Promise<void> {
 async function loadPersistentSessionsFromDisk(): Promise<PersistedConsoleRecord[]> {
   const records = new Map<string, PersistedConsoleRecord>();
 
-  for (const filePath of [persistentSessionFilePath, legacyReloadSessionFilePath]) {
-    if (!filePath) {
-      continue;
-    }
-    for (const entry of await readPersistentSessionFile(filePath)) {
+  if (persistentSessionFilePath) {
+    for (const entry of await readPersistentSessionFile(persistentSessionFilePath)) {
       records.set(entry.terminal.runtime.sessionId, entry);
     }
   }
@@ -174,11 +166,9 @@ async function readPersistentSessionFile(filePath: string): Promise<PersistedCon
 }
 
 async function removePersistentSessionFiles(): Promise<void> {
-  await Promise.all(
-    [persistentSessionFilePath, legacyReloadSessionFilePath]
-      .filter((filePath): filePath is string => typeof filePath === "string")
-      .map((filePath) => fs.promises.rm(filePath, { force: true }).catch(() => {}))
-  );
+  if (persistentSessionFilePath) {
+    await fs.promises.rm(persistentSessionFilePath, { force: true }).catch(() => {});
+  }
 }
 
 function buildPersistentTerminalOptions(
@@ -263,12 +253,7 @@ function parsePersistentSessionState(value: unknown): PersistedConsoleRecord[] |
   if (!isObjectRecord(value)) {
     return undefined;
   }
-  const sessions =
-    Array.isArray(value.sessions)
-      ? value.sessions
-      : Array.isArray(value.consoles)
-        ? value.consoles
-        : undefined;
+  const sessions = Array.isArray(value.sessions) ? value.sessions : undefined;
   if (!sessions || !sessions.every(isPersistedConsoleRecord)) {
     return undefined;
   }
@@ -506,6 +491,22 @@ async function managePersistentSessions(context: vscode.ExtensionContext): Promi
       return;
     }
 
+    if (action.action === "detachAll") {
+      detachPersistentSessions(sessions.filter((session) => session.attached));
+      return;
+    }
+
+    if (action.action === "detach") {
+      const selected = await pickPersistentSessions(
+        sessions.filter((session) => session.attached),
+        "Select persistent R console sessions to detach"
+      );
+      if (selected.length > 0) {
+        detachPersistentSessions(selected);
+      }
+      return;
+    }
+
     if (action.action === "closeAll") {
       await closePersistentSessions(sessions, context);
       return;
@@ -585,6 +586,7 @@ async function pickManageAction(
   sessions: readonly ManagedPersistentSession[]
 ): Promise<ManageAction | undefined> {
   const detachedCount = sessions.filter((session) => !session.attached).length;
+  const attachedCount = sessions.length - detachedCount;
   const actions: ManageAction[] = [];
 
   if (detachedCount > 0) {
@@ -598,6 +600,21 @@ async function pickManageAction(
         label: "Attach All Detached Sessions",
         description: `${detachedCount} detached`,
         action: "attachAll",
+      }
+    );
+  }
+
+  if (attachedCount > 0) {
+    actions.push(
+      {
+        label: "Detach Session...",
+        description: `${attachedCount} attached`,
+        action: "detach",
+      },
+      {
+        label: "Detach All Attached Sessions",
+        description: `${attachedCount} attached`,
+        action: "detachAll",
       }
     );
   }
@@ -672,6 +689,45 @@ async function attachPersistentSessions(
     attachTerminal(record, true);
   }
   schedulePersistPersistentSessions();
+}
+
+function detachPersistentSessions(sessions: readonly ManagedPersistentSession[]): void {
+  for (const session of sessions) {
+    if (session.attachedRecord) {
+      detachConsoleRecord(session.attachedRecord);
+    }
+  }
+  persistPersistentSessions();
+}
+
+function detachConsoleRecord(record: ConsoleRecord): void {
+  const pid = record.pid;
+  const location = record.location;
+  const terminalToDispose = record.terminal;
+  const persistedTerminal = record.rTerminal.detachPersistentSession();
+  if (!persistedTerminal) {
+    return;
+  }
+
+  persistentSessionRecords.set(persistedTerminal.runtime.sessionId, {
+    terminal: persistedTerminal,
+    location,
+  });
+
+  if (terminalToDispose) {
+    ignoredTerminalCloseEvents.add(terminalToDispose);
+    if (typeof pid === "number") {
+      ignoredEditorClosePids.add(pid);
+      setTimeout(() => {
+        ignoredEditorClosePids.delete(pid);
+      }, 1000);
+    }
+  }
+
+  disposeConsoleRecord(record);
+  if (terminalToDispose) {
+    terminalToDispose.dispose();
+  }
 }
 
 function revealConsoleRecord(record: ConsoleRecord): void {
@@ -1239,9 +1295,6 @@ function persistPersistentSessions(): void {
   if (persisted.length === 0) {
     try {
       fs.rmSync(persistentSessionFilePath, { force: true });
-      if (legacyReloadSessionFilePath) {
-        fs.rmSync(legacyReloadSessionFilePath, { force: true });
-      }
     } catch {
     }
     return;
@@ -1255,9 +1308,6 @@ function persistPersistentSessions(): void {
       sessions: persisted,
     };
     fs.writeFileSync(persistentSessionFilePath, JSON.stringify(sessionState), "utf8");
-    if (legacyReloadSessionFilePath) {
-      fs.rmSync(legacyReloadSessionFilePath, { force: true });
-    }
   } catch {
   }
 }


### PR DESCRIPTION
Add single-session and detach-all actions to the persistent session manager, keep detached R backends alive for reattach, and bump the extension to 0.2.3.

chore: remove stale session compatibility and redundant comments