### PR TITLE
Fix/console lsp loopback host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to R Console will be documented in this file.
 
+## [0.2.4] - 2026-05-13
+
+### Fixed
+- Fixed console LSP startup on Windows by using a consistent loopback host between VS Code and the R language server helper.
+- Preserved the inherited environment when spawning the console LSP R process.
+- Avoided repeated semantic token retry loops when semantic tokens are unavailable.
+
 ## [0.2.3] - 2026-05-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsc-r-console",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsc-r-console",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@xterm/headless": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-r-console",
   "displayName": "R Console for VS Code",
   "description": "A lightweight R console for VS Code",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "RConsole",
   "license": "MIT",
   "icon": "images/Rlogo.png",

--- a/resources/r/console-language-server.R
+++ b/resources/r/console-language-server.R
@@ -24,9 +24,11 @@ if (!requireNamespace("languageserver", quietly = TRUE)) {
 }
 
 debug <- Sys.getenv("VSCR_LSP_DEBUG")
+host <- Sys.getenv("VSCR_LSP_HOST")
 port <- Sys.getenv("VSCR_LSP_PORT")
 
 debug <- if (nzchar(debug)) as.logical(debug) else FALSE
+host <- if (nzchar(host)) host else "127.0.0.1"
 port <- if (nzchar(port)) as.integer(port) else NULL
 
 tools::Rd2txt_options(underline_titles = FALSE)
@@ -101,7 +103,7 @@ console_text_document_did_close <- function(self, params) {
     languageserver:::text_document_did_close(self, params)
 }
 
-server <- languageserver:::LanguageServer$new("localhost", port)
+server <- languageserver:::LanguageServer$new(host, port)
 server$request_handlers[["rConsole/syncSessionState"]] <- function(self, id, params) {
     attached_packages <- normalize_character(params$attachedPackages)
     loaded_namespaces <- normalize_character(params$loadedNamespaces)

--- a/src/Language/consoleLspClient.ts
+++ b/src/Language/consoleLspClient.ts
@@ -556,7 +556,7 @@ export class ConsoleLspClient implements CompletionProvider {
   }
 
   private buildServerEnv(config: vscode.WorkspaceConfiguration): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = Object.create(process.env);
+    const env: NodeJS.ProcessEnv = { ...process.env };
     const debug = config.get<boolean>("lsp.debug") === true;
     const useRenvLibPath = config.get<boolean>("useRenvLibPath") === true;
     const lang = config.get<string>("lsp.lang") ?? "";

--- a/src/Language/consoleLspClient.ts
+++ b/src/Language/consoleLspClient.ts
@@ -22,6 +22,8 @@ import { SemanticTokensRequest } from "vscode-languageserver-protocol";
 import type { CompletionProvider } from "./completion";
 import type { SessionMemberCompletionItem } from "../Runtime/sessionWatcher";
 
+const CONSOLE_LSP_HOST = "127.0.0.1";
+
 type ConsoleLspClientOptions = {
   consoleId: string;
   extensionPath: string;
@@ -457,7 +459,7 @@ export class ConsoleLspClient implements CompletionProvider {
         rejectOnce(new Error("Console language server socket closed before connection."));
       });
 
-      server.listen(0, "127.0.0.1", () => {
+      server.listen(0, CONSOLE_LSP_HOST, () => {
         const address = server.address();
         if (!address || typeof address === "string") {
           this.pendingSocketServer = undefined;
@@ -467,6 +469,7 @@ export class ConsoleLspClient implements CompletionProvider {
         }
         const env: NodeJS.ProcessEnv = {
           ...baseEnv,
+          VSCR_LSP_HOST: CONSOLE_LSP_HOST,
           VSCR_LSP_PORT: String(address.port),
         };
         const child = spawn(this.options.rPath, args, {

--- a/src/Terminal/consoleSyntax.ts
+++ b/src/Terminal/consoleSyntax.ts
@@ -161,8 +161,19 @@ export class ConsoleSyntax implements RendererLineHighlighter {
       ) {
         const requestedVersion = this.wantedSemanticVersion;
         const requestedContent = this.sourceKey;
-        const semanticTokens = await this.requestSemantics(requestedContent);
-        if (!semanticTokens || requestedVersion !== this.sourceVersion) {
+        let semanticTokens: DocumentSemanticTokensResult | undefined;
+        try {
+          semanticTokens = await this.requestSemantics(requestedContent);
+        } catch {
+          semanticTokens = undefined;
+        }
+
+        if (requestedVersion !== this.sourceVersion) {
+          continue;
+        }
+
+        if (!semanticTokens) {
+          this.appliedSemanticVersion = requestedVersion;
           continue;
         }
 


### PR DESCRIPTION
## Summary

Fixes console LSP startup on Windows by using a consistent loopback host between the VS Code socket server and the R language server helper. The LSP process now receives the explicit host via `VSCR_LSP_HOST`, while preserving the full inherited environment when spawning R.

This also prevents semantic token failures from causing repeated retry loops when semantic tokens are unavailable


