### PR TITLE
Reuse previous released bundled sidecar binaries if they are not changed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,82 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
 
+      - name: Restore sidecar from previous release
+        id: restore-sidecar
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          restored=false
+          trap 'echo "restored=${restored}" >> "$GITHUB_OUTPUT"' EXIT
+
+          if ! command -v gh >/dev/null || ! command -v unzip >/dev/null; then
+            echo "gh or unzip is unavailable; building sidecar."
+            exit 0
+          fi
+
+          git fetch --force --tags --quiet
+
+          current_tag="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
+            current_tag=""
+          fi
+          previous_tag="$(gh release list --exclude-drafts --exclude-pre-releases --limit 30 --json tagName --jq '.[].tagName' | awk -v current="${current_tag}" '$0 != current { print; exit }')"
+          if [[ -z "${previous_tag}" ]]; then
+            echo "No previous published release found; building sidecar."
+            exit 0
+          fi
+
+          sidecar_inputs=(sidecar/pty-host scripts/build-sidecar.js scripts/sidecar-targets.js)
+          if [[ "${TARGET}" == win32-* ]]; then
+            sidecar_inputs+=(images/Rlogo.ico)
+          fi
+          if ! git diff --quiet "${previous_tag}" HEAD -- "${sidecar_inputs[@]}"; then
+            echo "Sidecar build inputs changed; building sidecar."
+            exit 0
+          fi
+
+          rm -rf .restore-sidecar
+          mkdir -p .restore-sidecar bundled/bin
+          if ! gh release download "${previous_tag}" --pattern "*-${TARGET}.vsix" --dir .restore-sidecar --clobber; then
+            echo "Previous release ${previous_tag} has no VSIX for ${TARGET}; building sidecar."
+            exit 0
+          fi
+
+          vsix="$(find .restore-sidecar -type f -name "*-${TARGET}.vsix" | head -n 1)"
+          executable="R_CONSOLE_HOST"
+          if [[ "${TARGET}" == win32-* ]]; then
+            executable="R_CONSOLE_HOST.exe"
+          fi
+
+          if [[ -z "${vsix}" ]] || ! unzip -p "${vsix}" "extension/bundled/bin/${executable}" > "bundled/bin/${executable}"; then
+            rm -f "bundled/bin/${executable}"
+            echo "Could not extract ${executable} from ${previous_tag} VSIX; building sidecar."
+            exit 0
+          fi
+          if [[ "${executable}" != *.exe ]]; then
+            chmod 755 "bundled/bin/${executable}"
+          fi
+
+          echo "Restored bundled/bin/${executable} from ${previous_tag}/$(basename "${vsix}")."
+          restored=true
+
       - name: Setup Rust
+        if: steps.restore-sidecar.outputs.restored != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Rust target
+        if: steps.restore-sidecar.outputs.restored != 'true'
         run: rustup target add ${{ matrix.rust_target }}
 
       - name: Install dependencies
@@ -64,10 +130,18 @@ jobs:
         run: npm run package:extension
 
       - name: Build sidecar
+        if: steps.restore-sidecar.outputs.restored != 'true'
         run: node scripts/build-sidecar.js --target ${{ matrix.target }}
 
       - name: Stage sidecar
+        if: steps.restore-sidecar.outputs.restored != 'true'
         run: node scripts/stage-sidecar.js --target ${{ matrix.target }}
+
+      - name: Verify bundled sidecar
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          node -e "const fs=require('fs'); const expected=process.env.TARGET.startsWith('win32-')?'R_CONSOLE_HOST.exe':'R_CONSOLE_HOST'; const dir='bundled/bin'; const files=fs.readdirSync(dir,{withFileTypes:true}).filter(e=>e.isFile()).map(e=>e.name).sort(); if(files.length!==1||files[0]!==expected){throw new Error('Expected exactly one bundled sidecar (' + expected + ') in ' + dir + '; found: ' + files.join(', '));} console.log(dir + '/' + files[0]);"
 
       - name: Package extension
         run: node scripts/package-vsix.js --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         description: Publish the built VSIX packages to the VS Code Marketplace
         type: boolean
         default: false
+      publish_open_vsx:
+        description: Publish the built VSIX packages to the Open VSX Registry
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -253,3 +257,34 @@ jobs:
 
       - name: Publish VS Code Marketplace
         run: npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }} --skip-duplicate --packagePath ./release-artifacts/*.vsix
+
+  publish-open-vsx:
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish_open_vsx)
+    needs: package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          node -e "const pkg=require('./package.json'); const tag=process.env.GITHUB_REF_NAME; const expected='v' + pkg.version; if(tag !== expected){throw new Error('Tag ' + tag + ' does not match package version ' + expected);}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vsix-*
+          merge-multiple: true
+          path: release-artifacts
+
+      - name: Publish Open VSX Registry
+        env:
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: npx --yes ovsx publish --skip-duplicate --packagePath ./release-artifacts/*.vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to R Console will be documented in this file.
 
 ### Changed
 - Release packaging now reuses unchanged sidecar binaries from the previous GitHub release VSIX instead of rebuilding them for every extension release.
+- Release workflow now publishes the target-specific VSIX packages to the Open VSX Registry.
 
 ### Fixed
 - Fixed leading blank echo after stripped R comments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to R Console will be documented in this file.
 
-## [0.2.5] - 2026-05-14
+## [0.2.5] - 2026-05-15
 
 ### Changed
 - Release packaging now reuses unchanged sidecar binaries from the previous GitHub release VSIX instead of rebuilding them for every extension release.
+
+### Fixed
+- Fixed leading blank echo after stripped R comments.
 
 ## [0.2.4] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to R Console will be documented in this file.
 
+## [0.2.5] - 2026-05-14
+
+### Changed
+- Release packaging now reuses unchanged sidecar binaries from the previous GitHub release VSIX instead of rebuilding them for every extension release.
+
 ## [0.2.4] - 2026-05-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -2126,9 +2126,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsc-r-console",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsc-r-console",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/headless": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-r-console",
   "displayName": "R Console for VS Code",
   "description": "A lightweight R console for VS Code",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publisher": "RConsole",
   "license": "MIT",
   "icon": "images/Rlogo.png",

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -1064,7 +1064,9 @@ export async function enqueueRuntimeSubmission(
 }
 
 function normalizeSubmissionBlock(code: string): string {
-  return stripCommentLines(code.replace(/\n+$/, "")).trimEnd();
+  return stripCommentLines(code.replace(/\n+$/, ""))
+    .replace(/^(?:[ \t]*[\r\n])+/, "")
+    .trimEnd();
 }
 
 async function splitSubmissionBlocks(host: RuntimeHost, code: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Reuse unchanged bundled sidecar binaries from the previous GitHub release VSIX during release packaging, skipping Rust setup/build when sidecar inputs have not changed.
- Add release workflow validation to ensure each packaged target contains exactly one expected `R_CONSOLE_HOST` binary.
- Release workflow now publishes the target-specific VSIX packages to the Open VSX Registry.
- Fix R submission normalization so leading blank lines left behind after stripped full-line comments do not echo before the first real command.
- Bump extension version to `0.2.5`.

