### PR TITLE
Release of v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to R Console will be documented in this file.
 
+## [0.2.6] - 2026-05-20
+
+### Changed
+- Clarified R logo asset licensing in the project license.
+- Documented how to restore a dropped custom pseudoterminal UI from persistent sessions.
+
+### Fixed
+- Fixed duplicate R> prompts after console resize.
+
 ## [0.2.5] - 2026-05-15
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
+Source Code License
+
+Unless otherwise noted below, the source code and project documentation are
+licensed as follows:
+
 MIT License
 
 Copyright (c) 2025
@@ -19,3 +24,21 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Third-Party Asset Notice
+
+The R logo files in images/Rlogo.png and images/Rlogo.ico are based on the
+R logo, Copyright (c) 2016 The R Foundation, available from:
+
+https://www.r-project.org/logo/
+
+These logo assets are distributed in this project under the Creative Commons
+Attribution-ShareAlike 4.0 International License:
+
+https://creativecommons.org/licenses/by-sa/4.0/
+
+Changes made for this project: the logo was resized and packaged as
+images/Rlogo.png for the VS Code extension icon and terminal tab icon, and
+converted to images/Rlogo.ico for the Windows backend executable icon.
+
+Use of the R logo does not imply endorsement by The R Foundation.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Launch `R Console` from the Command Palette with:
 
 Use the session manager to attach to, detach from, or close running R Console sessions.
 
+### Restoring A Dropped Console UI
+
+R Console runs in a VS Code custom pseudoterminal. VS Code may close the terminal UI during multi-root workspace folder reorder or removal, and after extension host restart/reload.
+
+Use `R Console: Manage Persistent Sessions...` from the Command Palette, then choose `Attach Session...` or `Attach All Detached Sessions` to restore the console UI for the running session.
+
 The minimum vscode-R setup for R Console commands to work is:
 
 1. Install [vscode-R](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "vsc-r-console",
       "version": "0.2.5",
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@xterm/headless": "^6.0.0",
         "vscode-languageclient": "^9.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsc-r-console",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsc-r-console",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@xterm/headless": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A lightweight R console for VS Code",
   "version": "0.2.5",
   "publisher": "RConsole",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "icon": "images/Rlogo.png",
   "galleryBanner": {
     "color": "#2C6DB2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-r-console",
   "displayName": "R Console for VS Code",
   "description": "A lightweight R console for VS Code",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "publisher": "RConsole",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/Rlogo.png",

--- a/src/Terminal/rTerminal/runtime.ts
+++ b/src/Terminal/rTerminal/runtime.ts
@@ -1111,9 +1111,6 @@ function writeRuntimeSubmissionEcho(host: RuntimeHost, task: Submission): void {
   configureMainPrompt(host.renderer);
 
   if (host.promptVisible || host.inputState.text.length > 0) {
-    if (host.promptVisible) {
-      host.captureVisibleInputForReplay();
-    }
     host.clearInputRender();
     host.promptVisible = false;
   } else {


### PR DESCRIPTION
 - Fixes duplicate R> prompt after console resize.
 - Clarifies R logo asset licensing in LICENSE.
 - Documents how to restore a dropped R Console UI when it is closed by VS Code during multi-root workspace folder reorder/removal or extension host restart/reload.
 - Bumps version to 0.2.6.