### PR TITLE
Fixed completion search for packages with large list of members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to R Console will be documented in this file.
 
+## [0.2.9] - 2026-06-19
+
+### Fixed
+
+- Fixed completion search for packages with large list of members
+
 ## [0.2.8] - 2026-06-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsc-r-console",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsc-r-console",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@xterm/headless": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-r-console",
   "displayName": "R Console for VS Code",
   "description": "A lightweight R console for VS Code",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "publisher": "RConsole",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/Rlogo.png",

--- a/src/Terminal/rTerminal/lang.ts
+++ b/src/Terminal/rTerminal/lang.ts
@@ -120,11 +120,47 @@ export class RTermLang {
       }
 
       const picks = toCompletionQuickPickItems(entries, context);
-      const selection = await vscode.window.showQuickPick(picks, {
+      const pickOptions = {
         matchOnDescription: true,
         matchOnDetail: true,
         placeHolder: "R console completions",
-      });
+      };
+      const selection = context.kind !== "package"
+        ? await vscode.window.showQuickPick(picks, pickOptions)
+        : await new Promise<CompletionPickItem | undefined>((resolve) => {
+            const pick = vscode.window.createQuickPick<vscode.QuickPickItem>();
+            let request = 0;
+            Object.assign(pick, { matchOnDescription: true, matchOnDetail: true, placeholder: pickOptions.placeHolder, items: picks });
+            pick.onDidChangeValue((value) => void (async () => {
+              const currentRequest = ++request;
+              const prefix = value.startsWith(context.prefix) ? value : context.prefix + value;
+              const cursorCol = context.replaceStart + prefix.length;
+              const currentLine = latestInput.currentLine.slice(0, context.replaceStart) + prefix + latestInput.currentLine.slice(latestInput.cursorCol);
+              const lines = [...latestInput.lines];
+              lines[latestInput.cursorRow] = currentLine;
+              const nextDoc = this.getOrUpdateCompletionDocument(lines.join("\n"));
+              if (!nextDoc) {
+                return;
+              }
+              const nextContext = { ...context, prefix, triggerCharacter: prefix.length === 0 ? context.triggerCharacter : undefined, snapshotInput: currentLine, snapshotCursor: cursorCol };
+              await this.consoleLsp?.prepareDocument(nextDoc);
+              const nextEntries = await collectCompletionEntries(
+                nextContext,
+                nextDoc,
+                new vscode.Position(latestInput.cursorRow, cursorCol),
+                sessionData,
+                lines.slice(0, latestInput.cursorRow),
+                this.options.getRecentSessionEntries?.() ?? [],
+                this.consoleLsp
+              );
+              if (currentRequest === request) {
+                pick.items = toCompletionQuickPickItems(nextEntries, { ...nextContext, snapshotInput: latestInput.currentLine, snapshotCursor: latestInput.cursorCol });
+              }
+            })().catch(() => undefined));
+            pick.onDidAccept(() => { const item = pick.selectedItems[0]; resolve(isCompletionPickItem(item) ? item : undefined); pick.hide(); });
+            pick.onDidHide(() => { request += 1; pick.dispose(); resolve(undefined); });
+            pick.show();
+          });
 
       if (!isCompletionPickItem(selection)) {
         return;


### PR DESCRIPTION
Fix completion search for packages with large member lists.

Previously, triggering completion at `pkg::` showed only the initial static list returned by `languageserver`. For large packages, members outside that initial list could not be found by typing in the Quick Pick window; they only appeared after typing a prefix in the console first, such as `pkg::p`.

This changes package member completion to use a package-only `createQuickPick()` path that refreshes `pkg::` / `pkg:::` results while typing.